### PR TITLE
ci(dns): validate the ssl cert is not expired

### DIFF
--- a/.github/workflows/dns.yaml
+++ b/.github/workflows/dns.yaml
@@ -2,7 +2,7 @@
 name: DNS
 on: # yamllint disable-line rule:truthy
   schedule:
-    - cron: "0 0 * * 1" # Runs every Monday at midnight UTC
+    - cron: "0 10 21 * *" # Runs on the 21st of every month at 10 AM UTC
   workflow_dispatch:
 jobs:
   certbot:
@@ -46,6 +46,7 @@ jobs:
       - name: Shred certificates
         run: shred -u certbot-config/archive/*/*
   deploy:
+    needs: certbot
     runs-on: ${{ vars.RUNS_ON }}
     permissions:
       id-token: write # This is required for requesting the JWT

--- a/ansible/roles/game-server/tasks/main.yml
+++ b/ansible/roles/game-server/tasks/main.yml
@@ -36,6 +36,16 @@
         owner: root
         group: root
         mode: '0644'
+    - name: Verify SSL is not expired
+      community.crypto.x509_certificate_info:
+        path: /etc/ssl/game.puma.stoneydavis.com/fullchain.pem
+        valid_at:
+          week_2: "+2w"
+      register: result
+    - name: Fail if SSL is expired
+      ansible.builtin.assert:
+        that:
+          - not result.valid_at.week_2
 - name: MariaDB
   ansible.builtin.include_role:
     name: xolyu.mariadb


### PR DESCRIPTION
Make the DNS workflow only fire off once a month. Make sure the deploy waits until certbot is done. Ensure that the ssl cert we've installed is not expired.
