### PR TITLE
fix(crunchy): disable dataSource

### DIFF
--- a/kubernetes/main/apps/database/crunchy-postgres-cluster/postgres-cluster.yaml
+++ b/kubernetes/main/apps/database/crunchy-postgres-cluster/postgres-cluster.yaml
@@ -87,14 +87,14 @@ spec:
           schedules:
             full: "0 2 * * 0" # Sunday at 02:00
             incremental: "0 2 * * 1-6/2" # Mon-Sat at 02:00, every 2nd day
-  dataSource:
-    pgbackrest:
-      stanza: "db"
-      configuration: *backupConfig
-      global: *backupFlag
-      repo:
-        name: "repo1"
-        s3: *backblaze
+  # dataSource:
+  #   pgbackrest:
+  #     stanza: "db"
+  #     configuration: *backupConfig
+  #     global: *backupFlag
+  #     repo:
+  #       name: "repo1"
+  #       s3: *backblaze
   monitoring:
     pgmonitor:
       exporter:


### PR DESCRIPTION
dataSource is used to bootstrap postgres, which is basically to restore from a fresh start, assuming you have backups, which we don't. so let's skip dataSource for now until we have backups
