### PR TITLE
fix(ansible-nfs): use the sysvinit

### DIFF
--- a/.cspell-dictionaries/linux.txt
+++ b/.cspell-dictionaries/linux.txt
@@ -61,3 +61,4 @@ svcgssd
 nfsvers
 nconnect
 noatime
+sysvinit

--- a/ansible/roles/nfs_server/handlers/main.yaml
+++ b/ansible/roles/nfs_server/handlers/main.yaml
@@ -1,5 +1,5 @@
 ---
 - name: Restart NFS server
-  ansible.builtin.systemd:
+  ansible.builtin.sysvinit:
     name: nfs-kernel-server
     state: restarted

--- a/ansible/roles/nfs_server/tasks/main.yaml
+++ b/ansible/roles/nfs_server/tasks/main.yaml
@@ -32,3 +32,8 @@
     name: nfs-kernel-server
     state: started
     enabled: true
+- name: Disable systemd service
+  ansible.builtin.systemd:
+    name: nfs-kernel-server
+    state: stopped
+    enabled: false

--- a/ansible/roles/nfs_server/tasks/main.yaml
+++ b/ansible/roles/nfs_server/tasks/main.yaml
@@ -28,7 +28,7 @@
     mode: "0644"
   notify: Restart NFS server
 - name: Start NFS server
-  ansible.builtin.systemd:
+  ansible.builtin.sysvinit:
     name: nfs-kernel-server
     state: started
     enabled: true


### PR DESCRIPTION
sysvinit reads the config files. the systemd does not
