### PR TITLE
fix(nfs): ensure all systemd services for nfs are disabled

### DIFF
--- a/.cspell-dictionaries/linux.txt
+++ b/.cspell-dictionaries/linux.txt
@@ -62,3 +62,4 @@ nfsvers
 nconnect
 noatime
 sysvinit
+idmapd

--- a/ansible/roles/nfs_server/tasks/main.yaml
+++ b/ansible/roles/nfs_server/tasks/main.yaml
@@ -28,13 +28,20 @@
     mode: "0644"
   notify: Restart NFS server
 - name: Disable systemd service
+  loop:
+    - nfs-mountd
+    - nfs-kernel-server
+    - nfs-server
+    - nfs-idmapd
   ansible.builtin.systemd_service:
-    name: nfs-kernel-server
+    name: "{{ item }}"
     state: stopped
-    masked: true
+    masked: false
     enabled: false
 - name: Start NFS server
   ansible.builtin.sysvinit:
     name: nfs-kernel-server
     state: started
     enabled: true
+  environment:
+    SYSTEMCTL_SKIP_REDIRECT: 1


### PR DESCRIPTION
masking is not necessary and breaks the script. however passing in an environment variable to skip the redirect is the right solution.
