### PR TITLE
fix(postgres): re-enable postgres cluster and pgadmin

### DIFF
--- a/kubernetes/main/apps/database/crunchy-postgres-cluster/kustomization.yaml
+++ b/kubernetes/main/apps/database/crunchy-postgres-cluster/kustomization.yaml
@@ -5,5 +5,5 @@ namespace: database
 resources:
   - ./pod-monitor.yaml
   - ./external-secret.yaml
-  # - ./postgres-cluster.yaml
-  # - ./postgres-admin.yaml
+  - ./postgres-cluster.yaml
+  - ./postgres-admin.yaml


### PR DESCRIPTION
Now that I've torn them down and removed broken backups. Relaunching the resources should cause the db and pgadmin to spin up with correct username/password and pgvecto.rs enabled.
