### PR TITLE
fix(postgres): spin cluster and pgadmin back down

### DIFF
--- a/kubernetes/main/apps/database/crunchy-postgres-cluster/kustomization.yaml
+++ b/kubernetes/main/apps/database/crunchy-postgres-cluster/kustomization.yaml
@@ -5,5 +5,5 @@ namespace: database
 resources:
   - ./pod-monitor.yaml
   - ./external-secret.yaml
-  - ./postgres-cluster.yaml
-  - ./postgres-admin.yaml
+  # - ./postgres-cluster.yaml
+  # - ./postgres-admin.yaml


### PR DESCRIPTION
Since I started the cluster with restore enabled it broke bootstrapping
