### PR TITLE
fix(renovate): argo-cd with an extract version

### DIFF
--- a/kubernetes/main/bootstrap/argocd/kustomization.yaml
+++ b/kubernetes/main/bootstrap/argocd/kustomization.yaml
@@ -3,7 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: argocd
 resources:
-  # renovate: datasource=github-releases depName=argoproj/argo-cd
+  # renovate: datasource=github-releases depName=argoproj/argo-cd extractVersion=^v(?<version>.*)$
   - https://raw.githubusercontent.com/argoproj/argo-cd/v2.11.5/manifests/install.yaml
 helmCharts:
   - name: cloudflare-tunnel


### PR DESCRIPTION
this should cause renovate to correctly find the version in the string
