### PR TITLE
fix(renovate): move group vars to yaml extension

### DIFF
--- a/.github/renovate/customManagers.json5
+++ b/.github/renovate/customManagers.json5
@@ -1,10 +1,9 @@
 {
-   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-   "customManagers": [
-      {
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "customManagers": [
+    {
       "customType": "regex",
       "description": "Process custom dependencies",
-
       "fileMatch": [
         "(^|/)kubernetes/.+\\.ya?ml$",
       ],
@@ -15,7 +14,6 @@
       "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver-coerced{{/if}}",
       "extractVersionTemplate": "{{#if extractVersion}}{{{extractVersion}}}{{/if}}"
     },
-
     {
       "description": "GitHub URL dependencies",
       "fileMatch": [

--- a/ansible/group_vars/all.yaml
+++ b/ansible/group_vars/all.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language server: $schema=https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/vars.json
 # version increment: 1 # this is being used to trigger the changed files check in CI
 k3s_git_repo: git@github.com:raypappa/homelab.git
 k3s_server_location: /var/lib/rancher/k3s

--- a/ansible/group_vars/dev_k8s_cluster.yaml
+++ b/ansible/group_vars/dev_k8s_cluster.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language server: $schema=https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/vars.json
 k3s_cloudflare_domain_name: devfieldsofbears.com
 master_ip: "{{ hostvars[groups['dev_k8s_controlplane'][0]]['ansible_host'] | default(groups['dev_k8s_controlplane'][0]) }}"
 singleton_host: "{{ groups['dev_k8s_controlplane'][0] }}"

--- a/ansible/group_vars/prod_k8s_cluster.yaml
+++ b/ansible/group_vars/prod_k8s_cluster.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language server: $schema=https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/vars.json
 k3s_cloudflare_domain_name: fieldsofbears.com
 master_ip: "{{ hostvars[groups['prod_k8s_controlplane'][0]]['ansible_host'] | default(groups['prod_k8s_controlplane'][0]) }}"
 singleton_host: "{{ groups['prod_k8s_controlplane'][0] }}"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Added YAML schema declarations to Ansible group variable files for improved validation and linting
	- Updated Renovate configuration with minor formatting adjustments

- **Chores**
	- Cleaned up JSON5 configuration by removing trailing commas
	- Improved consistency in configuration file formatting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->