### PR TITLE
fix(volsync): add yaml schemas and synchronize the settings for cache

### DIFF
--- a/kubernetes/main/apps/downloads/prowlarr/volsync-replication-destination.yaml
+++ b/kubernetes/main/apps/downloads/prowlarr/volsync-replication-destination.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/volsync.backube/replicationdestination_v1alpha1.json
 apiVersion: volsync.backube/v1alpha1
 kind: ReplicationDestination
 metadata:
@@ -10,10 +11,10 @@ spec:
     repository: prowlarr-config-volsync-backblaze-secret
     copyMethod: Snapshot
     volumeSnapshotClassName: ceph-block
-    cacheStorageClassName: local-path
+    cacheStorageClassName: openebs-hostpath
     cacheAccessModes:
       - ReadWriteOnce
-    cacheCapacity: 8Gi
+    cacheCapacity: 1Gi
     storageClassName: ceph-block
     accessModes:
       - ReadWriteOnce

--- a/kubernetes/main/apps/downloads/prowlarr/volsync-replication-source.yaml
+++ b/kubernetes/main/apps/downloads/prowlarr/volsync-replication-source.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/volsync.backube/replicationsource_v1alpha1.json
 apiVersion: volsync.backube/v1alpha1
 kind: ReplicationSource
 metadata:
@@ -12,8 +13,8 @@ spec:
     pruneIntervalDays: 7
     repository: prowlarr-config-volsync-backblaze-secret
     volumeSnapshotClassName: ceph-block
-    cacheCapacity: 8Gi
-    cacheStorageClassName: local-path
+    cacheCapacity: 1Gi
+    cacheStorageClassName: openebs-hostpath
     cacheAccessModes:
       - ReadWriteOnce
     storageClassName: ceph-block

--- a/kubernetes/main/apps/downloads/sonarr/pvc/config/volsync-replication-destination.yaml
+++ b/kubernetes/main/apps/downloads/sonarr/pvc/config/volsync-replication-destination.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/volsync.backube/replicationdestination_v1alpha1.json
 apiVersion: volsync.backube/v1alpha1
 kind: ReplicationDestination
 metadata:
@@ -10,10 +11,10 @@ spec:
     repository: sonarr-config-volsync-backblaze-secret
     copyMethod: Snapshot
     volumeSnapshotClassName: ceph-filesystem
-    cacheStorageClassName: local-path
+    cacheStorageClassName: openebs-hostpath
     cacheAccessModes:
       - ReadWriteOnce
-    cacheCapacity: 2Gi
+    cacheCapacity: 1Gi
     storageClassName: ceph-filesystem
     accessModes:
       - ReadWriteMany

--- a/kubernetes/main/apps/downloads/sonarr/pvc/config/volsync-replication-source.yaml
+++ b/kubernetes/main/apps/downloads/sonarr/pvc/config/volsync-replication-source.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/volsync.backube/replicationsource_v1alpha1.json
 apiVersion: volsync.backube/v1alpha1
 kind: ReplicationSource
 metadata:
@@ -12,8 +13,8 @@ spec:
     pruneIntervalDays: 7
     repository: sonarr-config-volsync-backblaze-secret
     volumeSnapshotClassName: ceph-filesystem
-    cacheCapacity: 2Gi
-    cacheStorageClassName: local-path
+    cacheCapacity: 1Gi
+    cacheStorageClassName: openebs-hostpath
     cacheAccessModes:
       - ReadWriteOnce
     storageClassName: ceph-filesystem

--- a/kubernetes/main/apps/media/plex2/pvc/cache/volsync-replication-destination.yaml
+++ b/kubernetes/main/apps/media/plex2/pvc/cache/volsync-replication-destination.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/volsync.backube/replicationdestination_v1alpha1.json
 apiVersion: volsync.backube/v1alpha1
 kind: ReplicationDestination
 metadata:
@@ -10,10 +11,13 @@ spec:
     repository: plex-cache-volsync-backblaze-secret
     copyMethod: Snapshot
     volumeSnapshotClassName: ceph-block
-    cacheStorageClassName: local-path
+    cleanupCachePVC: true
+    cleanupTempPVC: true
+    enableFileDeletion: true
+    cacheStorageClassName: openebs-hostpath
     cacheAccessModes:
       - ReadWriteOnce
-    cacheCapacity: 8Gi
+    cacheCapacity: 1Gi
     storageClassName: ceph-block
     accessModes:
       - ReadWriteOnce

--- a/kubernetes/main/apps/media/plex2/pvc/cache/volsync-replication-source.yaml
+++ b/kubernetes/main/apps/media/plex2/pvc/cache/volsync-replication-source.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/volsync.backube/replicationsource_v1alpha1.json
 apiVersion: volsync.backube/v1alpha1
 kind: ReplicationSource
 metadata:
@@ -12,8 +13,8 @@ spec:
     pruneIntervalDays: 7
     repository: plex-cache-volsync-backblaze-secret
     volumeSnapshotClassName: ceph-block
-    cacheCapacity: 8Gi
-    cacheStorageClassName: local-path
+    cacheCapacity: 1Gi
+    cacheStorageClassName: openebs-hostpath
     cacheAccessModes:
       - ReadWriteOnce
     storageClassName: ceph-block

--- a/kubernetes/main/apps/media/plex2/pvc/config/volsync-replication-destination.yaml
+++ b/kubernetes/main/apps/media/plex2/pvc/config/volsync-replication-destination.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/volsync.backube/replicationdestination_v1alpha1.json
 apiVersion: volsync.backube/v1alpha1
 kind: ReplicationDestination
 metadata:
@@ -10,10 +11,10 @@ spec:
     repository: plex-config-volsync-backblaze-secret
     copyMethod: Snapshot
     volumeSnapshotClassName: ceph-block
-    cacheStorageClassName: local-path
+    cacheStorageClassName: openebs-hostpath
     cacheAccessModes:
       - ReadWriteOnce
-    cacheCapacity: 8Gi
+    cacheCapacity: 1Gi
     storageClassName: ceph-block
     accessModes:
       - ReadWriteOnce

--- a/kubernetes/main/apps/media/plex2/pvc/config/volsync-replication-source.yaml
+++ b/kubernetes/main/apps/media/plex2/pvc/config/volsync-replication-source.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/volsync.backube/replicationsource_v1alpha1.json
 apiVersion: volsync.backube/v1alpha1
 kind: ReplicationSource
 metadata:
@@ -12,8 +13,8 @@ spec:
     pruneIntervalDays: 7
     repository: plex-config-volsync-backblaze-secret
     volumeSnapshotClassName: ceph-block
-    cacheCapacity: 8Gi
-    cacheStorageClassName: local-path
+    cacheCapacity: 1Gi
+    cacheStorageClassName: openebs-hostpath
     cacheAccessModes:
       - ReadWriteOnce
     storageClassName: ceph-block

--- a/kubernetes/main/apps/selfhosted/immich/volsync-replication-destination.yaml
+++ b/kubernetes/main/apps/selfhosted/immich/volsync-replication-destination.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/volsync.backube/replicationdestination_v1alpha1.json
 apiVersion: volsync.backube/v1alpha1
 kind: ReplicationDestination
 metadata:
@@ -10,10 +11,10 @@ spec:
     repository: immich-library-volsync-backblaze-secret
     copyMethod: Snapshot
     volumeSnapshotClassName: ceph-filesystem
-    cacheStorageClassName: local-path
+    cacheStorageClassName: openebs-hostpath
     cacheAccessModes:
       - ReadWriteOnce
-    cacheCapacity: 8Gi
+    cacheCapacity: 1Gi
     storageClassName: ceph-filesystem
     accessModes:
       - ReadWriteMany

--- a/kubernetes/main/apps/selfhosted/immich/volsync-replication-source.yaml
+++ b/kubernetes/main/apps/selfhosted/immich/volsync-replication-source.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/volsync.backube/replicationsource_v1alpha1.json
 apiVersion: volsync.backube/v1alpha1
 kind: ReplicationSource
 metadata:
@@ -12,8 +13,8 @@ spec:
     pruneIntervalDays: 7
     repository: immich-library-volsync-backblaze-secret
     volumeSnapshotClassName: ceph-filesystem
-    cacheCapacity: 8Gi
-    cacheStorageClassName: local-path
+    cacheCapacity: 1Gi
+    cacheStorageClassName: openebs-hostpath
     cacheAccessModes:
       - ReadWriteOnce
     storageClassName: ceph-filesystem

--- a/kubernetes/main/apps/selfhosted/lemonldap/volsync-replication-destination.yaml
+++ b/kubernetes/main/apps/selfhosted/lemonldap/volsync-replication-destination.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/volsync.backube/replicationdestination_v1alpha1.json
 apiVersion: volsync.backube/v1alpha1
 kind: ReplicationDestination
 metadata:
@@ -10,15 +11,16 @@ spec:
     repository: etc-lemonldap-ng-volsync-backblaze-secret
     copyMethod: Snapshot
     volumeSnapshotClassName: ceph-block
-    cacheStorageClassName: local-path
+    cacheStorageClassName: openebs-hostpath
     cacheAccessModes:
       - ReadWriteOnce
-    cacheCapacity: 8Gi
+    cacheCapacity: 1Gi
     storageClassName: ceph-block
     accessModes:
       - ReadWriteOnce
     capacity: 5Gi
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/volsync.backube/replicationdestination_v1alpha1.json
 apiVersion: volsync.backube/v1alpha1
 kind: ReplicationDestination
 metadata:
@@ -30,15 +32,16 @@ spec:
     repository: var-lib-lemonldap-ng-conf-volsync-backblaze-secret
     copyMethod: Snapshot
     volumeSnapshotClassName: ceph-block
-    cacheStorageClassName: local-path
+    cacheStorageClassName: openebs-hostpath
     cacheAccessModes:
       - ReadWriteOnce
-    cacheCapacity: 8Gi
+    cacheCapacity: 1Gi
     storageClassName: ceph-block
     accessModes:
       - ReadWriteOnce
     capacity: 5Gi
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/volsync.backube/replicationdestination_v1alpha1.json
 apiVersion: volsync.backube/v1alpha1
 kind: ReplicationDestination
 metadata:
@@ -50,15 +53,16 @@ spec:
     repository: var-lib-lemonldap-ng-sessions-volsync-backblaze-secret
     copyMethod: Snapshot
     volumeSnapshotClassName: ceph-block
-    cacheStorageClassName: local-path
+    cacheStorageClassName: openebs-hostpath
     cacheAccessModes:
       - ReadWriteOnce
-    cacheCapacity: 8Gi
+    cacheCapacity: 1Gi
     storageClassName: ceph-block
     accessModes:
       - ReadWriteOnce
     capacity: 5Gi
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/volsync.backube/replicationdestination_v1alpha1.json
 apiVersion: volsync.backube/v1alpha1
 kind: ReplicationDestination
 metadata:
@@ -70,10 +74,10 @@ spec:
     repository: var-lib-lemonldap-ng-psessions-volsync-backblaze-secret
     copyMethod: Snapshot
     volumeSnapshotClassName: ceph-block
-    cacheStorageClassName: local-path
+    cacheStorageClassName: openebs-hostpath
     cacheAccessModes:
       - ReadWriteOnce
-    cacheCapacity: 8Gi
+    cacheCapacity: 1Gi
     storageClassName: ceph-block
     accessModes:
       - ReadWriteOnce

--- a/kubernetes/main/apps/selfhosted/lemonldap/volsync-replication-source.yaml
+++ b/kubernetes/main/apps/selfhosted/lemonldap/volsync-replication-source.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/volsync.backube/replicationsource_v1alpha1.json
 apiVersion: volsync.backube/v1alpha1
 kind: ReplicationSource
 metadata:
@@ -12,8 +13,8 @@ spec:
     pruneIntervalDays: 7
     repository: lemonldap-config-volsync-backblaze-secret
     volumeSnapshotClassName: ceph-block
-    cacheCapacity: 8Gi
-    cacheStorageClassName: local-path
+    cacheCapacity: 1Gi
+    cacheStorageClassName: openebs-hostpath
     cacheAccessModes:
       - ReadWriteOnce
     storageClassName: ceph-block
@@ -26,6 +27,7 @@ spec:
     retain:
       daily: 7
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/volsync.backube/replicationsource_v1alpha1.json
 apiVersion: volsync.backube/v1alpha1
 kind: ReplicationSource
 metadata:
@@ -39,8 +41,8 @@ spec:
     pruneIntervalDays: 7
     repository: lemonldap-config-volsync-backblaze-secret
     volumeSnapshotClassName: ceph-block
-    cacheCapacity: 8Gi
-    cacheStorageClassName: local-path
+    cacheCapacity: 1Gi
+    cacheStorageClassName: openebs-hostpath
     cacheAccessModes:
       - ReadWriteOnce
     storageClassName: ceph-block
@@ -53,6 +55,7 @@ spec:
     retain:
       daily: 7
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/volsync.backube/replicationsource_v1alpha1.json
 apiVersion: volsync.backube/v1alpha1
 kind: ReplicationSource
 metadata:
@@ -66,8 +69,8 @@ spec:
     pruneIntervalDays: 7
     repository: lemonldap-config-volsync-backblaze-secret
     volumeSnapshotClassName: ceph-block
-    cacheCapacity: 8Gi
-    cacheStorageClassName: local-path
+    cacheCapacity: 1Gi
+    cacheStorageClassName: openebs-hostpath
     cacheAccessModes:
       - ReadWriteOnce
     storageClassName: ceph-block
@@ -80,6 +83,7 @@ spec:
     retain:
       daily: 7
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/volsync.backube/replicationsource_v1alpha1.json
 apiVersion: volsync.backube/v1alpha1
 kind: ReplicationSource
 metadata:
@@ -93,8 +97,8 @@ spec:
     pruneIntervalDays: 7
     repository: lemonldap-config-volsync-backblaze-secret
     volumeSnapshotClassName: ceph-block
-    cacheCapacity: 8Gi
-    cacheStorageClassName: local-path
+    cacheCapacity: 1Gi
+    cacheStorageClassName: openebs-hostpath
     cacheAccessModes:
       - ReadWriteOnce
     storageClassName: ceph-block

--- a/kubernetes/main/apps/selfhosted/timetagger/volsync-replication-destination.yaml
+++ b/kubernetes/main/apps/selfhosted/timetagger/volsync-replication-destination.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/volsync.backube/replicationdestination_v1alpha1.json
 apiVersion: volsync.backube/v1alpha1
 kind: ReplicationDestination
 metadata:
@@ -10,10 +11,10 @@ spec:
     repository: timetagger-config-volsync-backblaze-secret
     copyMethod: Snapshot
     volumeSnapshotClassName: ceph-block
-    cacheStorageClassName: local-path
+    cacheStorageClassName: openebs-hostpath
     cacheAccessModes:
       - ReadWriteOnce
-    cacheCapacity: 8Gi
+    cacheCapacity: 1Gi
     storageClassName: ceph-block
     accessModes:
       - ReadWriteOnce

--- a/kubernetes/main/apps/selfhosted/timetagger/volsync-replication-source.yaml
+++ b/kubernetes/main/apps/selfhosted/timetagger/volsync-replication-source.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/volsync.backube/replicationsource_v1alpha1.json
 apiVersion: volsync.backube/v1alpha1
 kind: ReplicationSource
 metadata:
@@ -12,8 +13,8 @@ spec:
     pruneIntervalDays: 7
     repository: timetagger-config-volsync-backblaze-secret
     volumeSnapshotClassName: ceph-block
-    cacheCapacity: 8Gi
-    cacheStorageClassName: local-path
+    cacheCapacity: 1Gi
+    cacheStorageClassName: openebs-hostpath
     cacheAccessModes:
       - ReadWriteOnce
     storageClassName: ceph-block

--- a/kubernetes/main/apps/system/rook-ceph-cluster/rook-ceph-cluster-values.yaml
+++ b/kubernetes/main/apps/system/rook-ceph-cluster/rook-ceph-cluster-values.yaml
@@ -43,55 +43,6 @@ cephBlockPoolsVolumeSnapshotClass:
 # -- A list of CephObjectStore configurations to deploy
 # @default -- See [below](#ceph-object-stores)
 cephObjectStores: []
-# - name: ceph-objectstore
-#   # see https://github.com/rook/rook/blob/master/Documentation/CRDs/Object-Storage/ceph-object-store-crd.md#object-store-settings for available configuration
-#   spec:
-#     metadataPool:
-#       failureDomain: host
-#       replicated:
-#         size: 2
-#     dataPool:
-#       failureDomain: host
-#       replicated:
-#         size: 2
-#     preservePoolsOnDelete: true
-#     gateway:
-#       port: 80
-#       resources:
-#         limits:
-#           memory: "2Gi"
-#         requests:
-#           cpu: "1000m"
-#           memory: "1Gi"
-#       # securePort: 443
-#       # sslCertificateRef:
-#       instances: 1
-#       priorityClassName: system-cluster-critical
-#   storageClass:
-#     enabled: true
-#     name: ceph-bucket
-#     reclaimPolicy: Delete
-#     volumeBindingMode: "Immediate"
-#     annotations: {}
-#     labels: {}
-#     # see https://github.com/rook/rook/blob/master/Documentation/Storage-Configuration/Object-Storage-RGW/ceph-object-bucket-claim.md#storageclass for available configuration
-#     parameters:
-#       # note: objectStoreNamespace and objectStoreName are configured by the chart
-#       region: us-east-1
-#   ingress:
-#     # Enable an ingress for the ceph-objectstore
-#     enabled: false
-#     # annotations: {}
-#     # host:
-#     #   name: objectstore.example.com
-#     #   path: /
-#     # tls:
-#     # - hosts:
-#     #     - objectstore.example.com
-#     #   secretName: ceph-objectstore-tls
-#     # ingressClassName: nginx
-# -- A list of CephFileSystem configurations to deploy
-# @default -- See [below](#ceph-file-systems)
 cephFileSystems:
   - name: ceph-filesystem
     # see https://github.com/rook/rook/blob/master/Documentation/CRDs/Shared-Filesystem/ceph-filesystem-crd.md#filesystem-settings for available configuration

--- a/kubernetes/main/apps/system/volsync/kustomization.yaml
+++ b/kubernetes/main/apps/system/volsync/kustomization.yaml
@@ -9,5 +9,6 @@ helmCharts:
     namespace: system
     releaseName: volsync
     version: 0.11.0
+    valuesFile: values.yaml
 resources:
   - prometheus-rule.yaml

--- a/kubernetes/main/apps/system/volsync/values.yaml
+++ b/kubernetes/main/apps/system/volsync/values.yaml
@@ -1,0 +1,2 @@
+---
+manageCRDs: true

--- a/kubernetes/main/templates/volsync/backblaze.yaml
+++ b/kubernetes/main/templates/volsync/backblaze.yaml
@@ -37,7 +37,7 @@ spec:
     pruneIntervalDays: 7
     repository: "${APP}-volsync-backblaze-secret"
     volumeSnapshotClassName: "${VOLSYNC_SNAPSHOTCLASS:-ceph-block}"
-    cacheCapacity: "${VOLSYNC_CACHE_CAPACITY:-8Gi}"
+    cacheCapacity: 1Gi
     cacheStorageClassName: "${VOLSYNC_CACHE_SNAPSHOTCLASS:-local-path}"
     cacheAccessModes: ["${VOLSYNC_CACHE_ACCESSMODES:-ReadWriteOnce}"]
     storageClassName: "${VOLSYNC_STORAGECLASS:-ceph-block}"
@@ -63,7 +63,7 @@ spec:
     volumeSnapshotClassName: "${VOLSYNC_SNAPSHOTCLASS:-ceph-block}"
     cacheStorageClassName: "${VOLSYNC_CACHE_SNAPSHOTCLASS:-local-path}"
     cacheAccessModes: ["${VOLSYNC_CACHE_ACCESSMODES:-ReadWriteOnce}"]
-    cacheCapacity: "${VOLSYNC_CACHE_CAPACITY:-8Gi}"
+    cacheCapacity: 1Gi
     storageClassName: "${VOLSYNC_STORAGECLASS:-ceph-block}"
     accessModes: ["${VOLSYNC_ACCESSMODES:-ReadWriteOnce}"]
     capacity: "${VOLSYNC_CAPACITY}"

--- a/kubernetes/main/templates/volsync/r2.yaml
+++ b/kubernetes/main/templates/volsync/r2.yaml
@@ -37,7 +37,7 @@ spec:
     pruneIntervalDays: 7
     repository: "${APP}-volsync-r2-secret"
     volumeSnapshotClassName: "${VOLSYNC_SNAPSHOTCLASS:-ceph-block}"
-    cacheCapacity: "${VOLSYNC_CACHE_CAPACITY:-4Gi}"
+    cacheCapacity: 1Gi
     cacheStorageClassName: "${VOLSYNC_CACHE_SNAPSHOTCLASS:-openebs-hostpath}"
     cacheAccessModes: ["${VOLSYNC_CACHE_ACCESSMODES:-ReadWriteOnce}"]
     storageClassName: "${VOLSYNC_STORAGECLASS:-ceph-block}"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration Updates**
	- Reduced cache capacity from 8Gi to 1Gi across multiple services
	- Updated storage class from `local-path` to `openebs-hostpath`
	- Added new configuration options for VolSync CRD management

- **New Features**
	- Introduced new cache management settings for replication destinations

- **Chores**
	- Cleaned up commented configurations in Rook Ceph cluster values
	- Added values file for VolSync Helm chart configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->