### PR TITLE
feat(domain-prefix): update all external domains with app

### DIFF
--- a/kubernetes/main/apps/downloads/prowlarr/kustomization.yaml
+++ b/kubernetes/main/apps/downloads/prowlarr/kustomization.yaml
@@ -16,7 +16,7 @@ helmCharts:
         secretName: "prowlarr-tunnel-credentials"
         tunnelName: "faerun-prowlarr"
         ingress:
-          - hostname: "prowlarr.fieldsofbears.com"
+          - hostname: "prowlarr.app.fieldsofbears.com"
             service: "http://prowlarr.homelab.svc.cluster.local:9696"
   - name: app-template
     includeCRDs: true

--- a/kubernetes/main/apps/downloads/radarr/tunnel.yaml
+++ b/kubernetes/main/apps/downloads/radarr/tunnel.yaml
@@ -22,7 +22,7 @@ spec:
           secretName: "radarr-tunnel-credentials"
           tunnelName: "faerun-radarr"
           ingress:
-            - hostname: "radarr.fieldsofbears.com"
+            - hostname: "radarr.app.fieldsofbears.com"
               service: "http://radarr-svc.homelab.svc.cluster.local:7878"
   destination:
     server: "https://kubernetes.default.svc"

--- a/kubernetes/main/apps/downloads/readarr/tunnel.yaml
+++ b/kubernetes/main/apps/downloads/readarr/tunnel.yaml
@@ -22,7 +22,7 @@ spec:
           secretName: "readarr-tunnel-credentials"
           tunnelName: "faerun-readarr"
           ingress:
-            - hostname: "readarr.fieldsofbears.com"
+            - hostname: "readarr.app.fieldsofbears.com"
               service: "http://readarr-svc.homelab.svc.cluster.local:8787"
   destination:
     server: "https://kubernetes.default.svc"

--- a/kubernetes/main/apps/downloads/rtorrent/tunnel.yaml
+++ b/kubernetes/main/apps/downloads/rtorrent/tunnel.yaml
@@ -22,7 +22,7 @@ spec:
           secretName: "rtorrent-tunnel-credentials"
           tunnelName: "faerun-rtorrent"
           ingress:
-            - hostname: "flood.fieldsofbears.com"
+            - hostname: "flood.app.fieldsofbears.com"
               service: "http://rtorrent-app.homelab.svc.cluster.local:3000"
   destination:
     server: "https://kubernetes.default.svc"

--- a/kubernetes/main/apps/downloads/sonarr/cloudflare-values.yaml
+++ b/kubernetes/main/apps/downloads/sonarr/cloudflare-values.yaml
@@ -6,5 +6,5 @@ cloudflare:
   secretName: "sonarr-tunnel-credentials"
   tunnelName: "faerun-sonarr"
   ingress:
-    - hostname: "sonarr.fieldsofbears.com"
+    - hostname: "sonarr.app.fieldsofbears.com"
       service: "http://sonarr.sonarr.svc.cluster.local:8989"

--- a/kubernetes/main/apps/downloads/whisparr/tunnel.yaml
+++ b/kubernetes/main/apps/downloads/whisparr/tunnel.yaml
@@ -22,7 +22,7 @@ spec:
           secretName: "whisparr-tunnel-credentials"
           tunnelName: "faerun-whisparr"
           ingress:
-            - hostname: "whisparr.fieldsofbears.com"
+            - hostname: "whisparr.app.fieldsofbears.com"
               service: "http://whisparr-svc.homelab.svc.cluster.local:6969"
   destination:
     server: "https://kubernetes.default.svc"

--- a/kubernetes/main/apps/monitoring/combined/tunnel.yaml
+++ b/kubernetes/main/apps/monitoring/combined/tunnel.yaml
@@ -22,9 +22,9 @@ spec:
           secretName: "monitoring-tunnel-credentials"
           tunnelName: "faerun-monitoring"
           ingress:
-            - hostname: "grafana.fieldsofbears.com"
+            - hostname: "grafana.app.fieldsofbears.com"
               service: "http://monitoring-lgtm-grafana.monitoring.svc.cluster.local:80"
-            - hostname: "prometheus.fieldsofbears.com"
+            - hostname: "prometheus.app.fieldsofbears.com"
               service: "http://prometheus-operated.monitoring.svc.cluster.local:9090"
               # annotations:
               #   gethomepage.dev/enabled: 'true'

--- a/kubernetes/main/apps/selfhosted/homepage/homepage-values.yaml
+++ b/kubernetes/main/apps/selfhosted/homepage/homepage-values.yaml
@@ -58,7 +58,7 @@ config:
     - Productivity:
         - Leantime:
             - abbr: lt
-              href: https://lt.fieldsofbears.com/
+              href: https://lt.app.fieldsofbears.com/
     - Developer:
         - Infrastructure:
             - abbr: infra
@@ -75,7 +75,7 @@ config:
   services:
     - Kubernetes:
         - ArgoCD:
-            href: https://argocd.fieldsofbears.com
+            href: https://argocd.app.fieldsofbears.com
             icon: argocd.svg
             app: argocd-server
             namespace: argocd
@@ -89,7 +89,7 @@ config:
             #     - name: Total Apps
             #       query: sum(argocd_app_info)
         - Ceph:
-            href: https://rook.fieldsofbears.com
+            href: https://rook.app.fieldsofbears.com
             icon: ceph.svg
             app: ceph-mgr
             namespace: rook-ceph
@@ -119,18 +119,18 @@ config:
               key: "{{HOMEPAGE_VAR_PTERODACTYL_API_KEY}}"
     - Monitoring:
         - Grafana:
-            href: https://grafana.fieldsofbears.com
+            href: https://grafana.app.fieldsofbears.com
             icon: grafana.svg
             namespace: monitoring
             app: grafana
         - Prometheus:
-            href: https://prometheus.fieldsofbears.com
+            href: https://prometheus.app.fieldsofbears.com
             icon: prometheus.svg
             namespace: monitoring
             app: prometheus
     - Development:
         - AI:
-            href: https://ai.fieldsofbears.com
+            href: https://ai.app.fieldsofbears.com
     - Media:
         - Plex:
             href: https://potato.fieldsofbears.com/web/index.html#!/
@@ -147,7 +147,7 @@ config:
                 - albums
     - Downloads:
         - Sonarr:
-            href: https://sonarr.fieldsofbears.com
+            href: https://sonarr.app.fieldsofbears.com
             icon: sonarr.svg
             namespace: homelab
             app: sonarr
@@ -157,7 +157,7 @@ config:
               key: "{{HOMEPAGE_VAR_SONARR_API_KEY}}"
               enableQueue: true # optional, defaults to false
         - Radarr:
-            href: https://radarr.fieldsofbears.com
+            href: https://radarr.app.fieldsofbears.com
             namespace: homelab
             app: radarr-svc
             icon: radarr.svg
@@ -171,7 +171,7 @@ config:
                 - queue
                 - movies
         - Readarr:
-            href: https://readarr.fieldsofbears.com
+            href: https://readarr.app.fieldsofbears.com
             namespace: homelab
             app: readarr-svc
             icon: readarr.svg
@@ -184,12 +184,12 @@ config:
                 - queued
                 - books
         - Whisparr:
-            href: https://whisparr.fieldsofbears.com
+            href: https://whisparr.app.fieldsofbears.com
             namespace: homelab
             app: whisparr-svc
             icon: whisparr.svg
         - Prowlarr:
-            href: https://prowlarr.fieldsofbears.com
+            href: https://prowlarr.app.fieldsofbears.com
             app: prowlarr-svc
             namespace: homelab
             icon: prowlarr.svg
@@ -203,7 +203,7 @@ config:
                 - numberOfFailGrabs
                 - numberOfFailQueries
         - Flood:
-            href: https://flood.fieldsofbears.com
+            href: https://flood.app.fieldsofbears.com
             namespace: homelab
             app: rtorrent-app
             icon: flood.svg

--- a/kubernetes/main/apps/selfhosted/immich/cloudflare-values.yaml
+++ b/kubernetes/main/apps/selfhosted/immich/cloudflare-values.yaml
@@ -6,5 +6,5 @@ cloudflare:
   secretName: "immich-tunnel-credentials"
   tunnelName: "faerun-immich"
   ingress:
-    - hostname: "immich.fieldsofbears.com"
+    - hostname: "immich.app.fieldsofbears.com"
       service: "http://immich-server-server.selfhosted.svc.cluster.local:3001"

--- a/kubernetes/main/apps/selfhosted/joplin/cloudflare-values.yaml
+++ b/kubernetes/main/apps/selfhosted/joplin/cloudflare-values.yaml
@@ -6,5 +6,5 @@ cloudflare:
   secretName: "joplin-tunnel-credentials"
   tunnelName: "faerun-joplin"
   ingress:
-    - hostname: "joplin.fieldsofbears.com"
+    - hostname: "joplin.app.fieldsofbears.com"
       service: "http://joplin.joplin.svc.cluster.local:8080"

--- a/kubernetes/main/apps/selfhosted/joplin/joplin-values.yaml
+++ b/kubernetes/main/apps/selfhosted/joplin/joplin-values.yaml
@@ -10,7 +10,7 @@ controllers:
           # renovate: datasource=docker depName=joplin/server
           tag: 3.0.1-beta
         env:
-          APP_BASE_URL: https://joplin.fieldsofbears.com
+          APP_BASE_URL: https://joplin.app.fieldsofbears.com
           APP_PORT: &port 8080
           TZ: America/Los_Angeles
           DB_CLIENT: pg
@@ -47,7 +47,7 @@ controllers:
               httpGet:
                 httpHeaders:
                   - name: Host
-                    value: "joplin.fieldsofbears.com"
+                    value: "joplin.app.fieldsofbears.com"
                 path: /api/ping
                 port: *port
               initialDelaySeconds: 0

--- a/kubernetes/main/apps/selfhosted/leantime/leantime.yaml
+++ b/kubernetes/main/apps/selfhosted/leantime/leantime.yaml
@@ -82,7 +82,7 @@ spec:
                   # Lots of this is pulled wholesale from
                   # https://github.com/Leantime/docker-leantime/blob/master/sample.env
                   LEAN_PORT: "80"
-                  LEAN_APP_URL: "https://lt.fieldsofbears.com"
+                  LEAN_APP_URL: "https://lt.app.fieldsofbears.com"
                   LEAN_APP_DIR: ""
                   LEAN_DEBUG: "0"
                   # MariaDB stuff here

--- a/kubernetes/main/apps/selfhosted/leantime/tunnel.yaml
+++ b/kubernetes/main/apps/selfhosted/leantime/tunnel.yaml
@@ -22,7 +22,7 @@ spec:
           secretName: "leantime-tunnel-credentials"
           tunnelName: "faerun-leantime"
           ingress:
-            - hostname: "lt.fieldsofbears.com"
+            - hostname: "lt.app.fieldsofbears.com"
               service: "http://leantime-svc-main.leantime.svc.cluster.local:80"
   destination:
     server: "https://kubernetes.default.svc"

--- a/kubernetes/main/apps/selfhosted/ollama/cloudflare-values.yaml
+++ b/kubernetes/main/apps/selfhosted/ollama/cloudflare-values.yaml
@@ -6,5 +6,5 @@ cloudflare:
   secretName: "ollama-tunnel-credentials"
   tunnelName: "faerun-ollama"
   ingress:
-    - hostname: "ai.fieldsofbears.com"
+    - hostname: "ai.app.fieldsofbears.com"
       service: "http://open-webui.ollama.svc.cluster.local:8080"

--- a/kubernetes/main/apps/selfhosted/stirling-pdf/cloudflare-values.yaml
+++ b/kubernetes/main/apps/selfhosted/stirling-pdf/cloudflare-values.yaml
@@ -6,5 +6,5 @@ cloudflare:
   secretName: "stirling-pdf-tunnel-credentials"
   tunnelName: "faerun-stirling-pdf"
   ingress:
-    - hostname: "stirling.fieldsofbears.com"
+    - hostname: "stirling.app.fieldsofbears.com"
       service: "http://stirling-pdf-stirling-pdf-chart.stirling-pdf.svc.cluster.local:8080"

--- a/kubernetes/main/apps/selfhosted/timetagger/kustomization.yaml
+++ b/kubernetes/main/apps/selfhosted/timetagger/kustomization.yaml
@@ -16,7 +16,7 @@ helmCharts:
         secretName: "timetagger-tunnel-credentials"
         tunnelName: "faerun-timetagger"
         ingress:
-          - hostname: "timetagger.fieldsofbears.com"
+          - hostname: "timetagger.app.fieldsofbears.com"
             service: "http://timetagger.timetagger.svc.cluster.local:80"
   - name: app-template
     includeCRDs: true

--- a/kubernetes/main/apps/system/rook-ceph-cluster/cloudflare-values.yaml
+++ b/kubernetes/main/apps/system/rook-ceph-cluster/cloudflare-values.yaml
@@ -6,5 +6,5 @@ cloudflare:
   secretName: "rook-ceph-tunnel-credentials"
   tunnelName: "faerun-rook-ceph"
   ingress:
-    - hostname: "rook.fieldsofbears.com"
+    - hostname: "rook.app.fieldsofbears.com"
       service: "http://rook-ceph-mgr-dashboard.rook-ceph.svc.cluster.local:7000"

--- a/kubernetes/main/bootstrap/argocd/kustomization.yaml
+++ b/kubernetes/main/bootstrap/argocd/kustomization.yaml
@@ -12,7 +12,7 @@ helmCharts:
     valuesInline:
       cloudflare:
         ingress:
-          - hostname: argocd.fieldsofbears.com
+          - hostname: argocd.app.fieldsofbears.com
             service: http://argocd-server.argocd.svc.cluster.local:80
         secretName: argocd-tunnel-credentials
         tunnelName: faerun-argocd

--- a/kubernetes/main/bootstrap/argocd/patches/argocd-cm.yaml
+++ b/kubernetes/main/bootstrap/argocd/patches/argocd-cm.yaml
@@ -4,7 +4,7 @@ kind: ConfigMap
 metadata:
   name: argocd-cm
 data:
-  url: https://argocd.fieldsofbears.com
+  url: https://argocd.app.fieldsofbears.com
   kustomize.buildOptions: --enable-helm
   accounts.homepage: apiKey
   accounts.cdavis: login, apiKey


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Unified service access URLs by switching from the legacy domain to the new domain (app.fieldsofbears.com) across multiple applications. Users may need to update bookmarks and links to continue accessing their services seamlessly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->