### PR TITLE
feat(ansible): bootstrap cluster

### DIFF
--- a/.cspell-dictionaries/ansible.txt
+++ b/.cspell-dictionaries/ansible.txt
@@ -21,3 +21,4 @@ markosamuli
 lazydocker
 tflint
 tfenv
+hussainweb

--- a/.cspell-dictionaries/linux.txt
+++ b/.cspell-dictionaries/linux.txt
@@ -73,3 +73,4 @@ oknodo
 nicelevel
 rpcsec
 unexporting
+chezmoi

--- a/.github/workflows/dns.yaml
+++ b/.github/workflows/dns.yaml
@@ -43,7 +43,7 @@ jobs:
         uses: docker://certbot/dns-route53
         with:
           args: >
-            certonly --non-interactive --agree-tos --email ${{ secrets.CERTBOT_EMAIL }} --dns-route53 --domains ${{ secrets.CERTBOT_DOMAINS }} --config-dir /github/workspace/certbot-config --work-dir /github/workspace/certbot-work --logs-dir /github/workspace/certbot-logs --keep-until-expiring --quiet --test-cert
+            certonly --non-interactive --agree-tos --email ${{ secrets.CERTBOT_EMAIL }} --dns-route53 --domains ${{ secrets.CERTBOT_DOMAINS }} --config-dir /github/workspace/certbot-config --work-dir /github/workspace/certbot-work --logs-dir /github/workspace/certbot-logs --keep-until-expiring --quiet
 
       - name: Fix file permissions
         uses: docker://certbot/dns-route53

--- a/.github/workflows/dns.yaml
+++ b/.github/workflows/dns.yaml
@@ -70,7 +70,7 @@ jobs:
           CERTIFICATE=$(cat ${CERT_PATH}/cert1.pem)
           RENEWAL=$(cat ${RENEWAL_PATH}/${first_domain}.conf)
           SECRET_STRING=$(jq -n --arg cert "$CERTIFICATE" --arg key "$PRIVATE_KEY" --arg chain "$CERTIFICATE_CHAIN" --arg fullchain "$FULLCHAIN"  --arg renewal "$RENEWAL" \
-          '{"certificate": $cert, "private_key": $key, "certificate_chain": $chain, "fullchain": $fullchain}, "renewal": ${renewal}')
+          '{"certificate": $cert, "private_key": $key, "certificate_chain": $chain, "fullchain": $fullchain, "renewal": $renewal')
           aws secretsmanager update-secret --secret-id ${first_domain}-cert --secret-string "$SECRET_STRING"
       - name: Shred certificates
         run: shred -u certbot-config/archive/*/*

--- a/.github/workflows/dns.yaml
+++ b/.github/workflows/dns.yaml
@@ -56,6 +56,7 @@ jobs:
           echo "::add-mask::${first_domain}"
           find certbot-config/live -ls
           find certbot-config/archive -ls
+          find certbot-config/renewal -ls
       - name: Upload certificate to AWS Secrets Manager
         run: |
           echo "::add-mask::$(aws sts get-caller-identity --query Account --output text)"

--- a/.github/workflows/dns.yaml
+++ b/.github/workflows/dns.yaml
@@ -16,29 +16,29 @@ jobs:
         with:
           role-to-assume: ${{ vars.AWS_ASSUME_ROLE_ARN }}
           aws-region: ${{ vars.AWS_DEFAULT_REGION }}
-      # - name: Retrieve certificate from AWS Secrets Manager
-      #   run: |
-      #     first_domain=$(echo ${{ secrets.CERTBOT_DOMAINS }} | cut -d',' -f1)
-      #     echo "::add-mask::${first_domain}-cert"
-      #     SECRET_STRING=$(aws secretsmanager get-secret-value --secret-id ${first_domain}-cert --query SecretString --output text)
-      #     CERT_PATH="certbot-config/archive/${first_domain}"
-      #     LIVE_PATH="certbot-config/live/${first_domain}"
-      #     mkdir -p ${CERT_PATH} ${LIVE_PATH} certbot-config/renewal
-      #     echo "$SECRET_STRING" | jq -r .fullchain > ${CERT_PATH}/fullchain1.pem
-      #     echo "$SECRET_STRING" | jq -r .private_key > ${CERT_PATH}/privkey1.pem
-      #     echo "$SECRET_STRING" | jq -r .certificate_chain > ${CERT_PATH}/chain1.pem
-      #     echo "$SECRET_STRING" | jq -r .certificate > ${CERT_PATH}/cert1.pem
-      #     echo "$SECRET_STRING" | jq -r .renewal > certbot-config/renewal/${first_domain}.conf
-      #     ln -s ${CERT_PATH}/fullchain1.pem ${LIVE_PATH}/fullchain.pem
-      #     ln -s ${CERT_PATH}/privkey1.pem ${LIVE_PATH}/privkey.pem
-      #     ln -s ${CERT_PATH}/chain1.pem ${LIVE_PATH}/chain.pem
-      #     ln -s ${CERT_PATH}/cert1.pem ${LIVE_PATH}/cert.pem
-      # - name: debug
-      #   run: |
-      #     first_domain=$(echo ${{ secrets.CERTBOT_DOMAINS }} | cut -d',' -f1)
-      #     echo "::add-mask::${first_domain}"
-      #     find certbot-config/live -ls
-      #     find certbot-config/archive -ls
+      - name: Retrieve certificate from AWS Secrets Manager
+        run: |
+          first_domain=$(echo ${{ secrets.CERTBOT_DOMAINS }} | cut -d',' -f1)
+          echo "::add-mask::${first_domain}-cert"
+          SECRET_STRING=$(aws secretsmanager get-secret-value --secret-id ${first_domain}-cert --query SecretString --output text)
+          CERT_PATH="certbot-config/archive/${first_domain}"
+          LIVE_PATH="certbot-config/live/${first_domain}"
+          mkdir -p ${CERT_PATH} ${LIVE_PATH} certbot-config/renewal
+          echo "$SECRET_STRING" | jq -r .fullchain > ${CERT_PATH}/fullchain1.pem
+          echo "$SECRET_STRING" | jq -r .private_key > ${CERT_PATH}/privkey1.pem
+          echo "$SECRET_STRING" | jq -r .certificate_chain > ${CERT_PATH}/chain1.pem
+          echo "$SECRET_STRING" | jq -r .certificate > ${CERT_PATH}/cert1.pem
+          echo "$SECRET_STRING" | jq -r .renewal > certbot-config/renewal/${first_domain}.conf
+          ln -s ${CERT_PATH}/fullchain1.pem ${LIVE_PATH}/fullchain.pem
+          ln -s ${CERT_PATH}/privkey1.pem ${LIVE_PATH}/privkey.pem
+          ln -s ${CERT_PATH}/chain1.pem ${LIVE_PATH}/chain.pem
+          ln -s ${CERT_PATH}/cert1.pem ${LIVE_PATH}/cert.pem
+      - name: debug
+        run: |
+          first_domain=$(echo ${{ secrets.CERTBOT_DOMAINS }} | cut -d',' -f1)
+          echo "::add-mask::${first_domain}"
+          find certbot-config/live -ls
+          find certbot-config/archive -ls
       - name: Generate certificate
         uses: docker://certbot/dns-route53
         with:

--- a/.github/workflows/dns.yaml
+++ b/.github/workflows/dns.yaml
@@ -70,7 +70,7 @@ jobs:
           CERTIFICATE=$(cat ${CERT_PATH}/cert1.pem)
           RENEWAL=$(cat ${RENEWAL_PATH}/${first_domain}.conf)
           SECRET_STRING=$(jq -n --arg cert "$CERTIFICATE" --arg key "$PRIVATE_KEY" --arg chain "$CERTIFICATE_CHAIN" --arg fullchain "$FULLCHAIN"  --arg renewal "$RENEWAL" \
-          '{"certificate": $cert, "private_key": $key, "certificate_chain": $chain, "fullchain": $fullchain, "renewal": $renewal')
+          '{"certificate": $cert, "private_key": $key, "certificate_chain": $chain, "fullchain": $fullchain, "renewal": $renewal}')
           aws secretsmanager update-secret --secret-id ${first_domain}-cert --secret-string "$SECRET_STRING"
       - name: Shred certificates
         run: shred -u certbot-config/archive/*/*

--- a/.github/workflows/dns.yaml
+++ b/.github/workflows/dns.yaml
@@ -16,28 +16,29 @@ jobs:
         with:
           role-to-assume: ${{ vars.AWS_ASSUME_ROLE_ARN }}
           aws-region: ${{ vars.AWS_DEFAULT_REGION }}
-      - name: Retrieve certificate from AWS Secrets Manager
-        run: |
-          first_domain=$(echo ${{ secrets.CERTBOT_DOMAINS }} | cut -d',' -f1)
-          echo "::add-mask::${first_domain}-cert"
-          SECRET_STRING=$(aws secretsmanager get-secret-value --secret-id ${first_domain}-cert --query SecretString --output text)
-          CERT_PATH="certbot-config/archive/${first_domain}"
-          LIVE_PATH="certbot-config/live/${first_domain}"
-          mkdir -p ${CERT_PATH} ${LIVE_PATH}
-          echo "$SECRET_STRING" | jq -r .fullchain > ${CERT_PATH}/fullchain1.pem
-          echo "$SECRET_STRING" | jq -r .private_key > ${CERT_PATH}/privkey1.pem
-          echo "$SECRET_STRING" | jq -r .certificate_chain > ${CERT_PATH}/chain1.pem
-          echo "$SECRET_STRING" | jq -r .certificate > ${CERT_PATH}/cert1.pem
-          ln -s ${CERT_PATH}/fullchain1.pem ${LIVE_PATH}/fullchain.pem
-          ln -s ${CERT_PATH}/privkey1.pem ${LIVE_PATH}/privkey.pem
-          ln -s ${CERT_PATH}/chain1.pem ${LIVE_PATH}/chain.pem
-          ln -s ${CERT_PATH}/cert1.pem ${LIVE_PATH}/cert.pem
-      - name: debug
-        run: |
-          first_domain=$(echo ${{ secrets.CERTBOT_DOMAINS }} | cut -d',' -f1)
-          echo "::add-mask::${first_domain}"
-          find certbot-config/live -ls
-          find certbot-config/archive -ls
+      # - name: Retrieve certificate from AWS Secrets Manager
+      #   run: |
+      #     first_domain=$(echo ${{ secrets.CERTBOT_DOMAINS }} | cut -d',' -f1)
+      #     echo "::add-mask::${first_domain}-cert"
+      #     SECRET_STRING=$(aws secretsmanager get-secret-value --secret-id ${first_domain}-cert --query SecretString --output text)
+      #     CERT_PATH="certbot-config/archive/${first_domain}"
+      #     LIVE_PATH="certbot-config/live/${first_domain}"
+      #     mkdir -p ${CERT_PATH} ${LIVE_PATH}
+      #     echo "$SECRET_STRING" | jq -r .fullchain > ${CERT_PATH}/fullchain1.pem
+      #     echo "$SECRET_STRING" | jq -r .private_key > ${CERT_PATH}/privkey1.pem
+      #     echo "$SECRET_STRING" | jq -r .certificate_chain > ${CERT_PATH}/chain1.pem
+      #     echo "$SECRET_STRING" | jq -r .certificate > ${CERT_PATH}/cert1.pem
+      #     echo "$SECRET_STRING" | jq -r .renewal > certbot-config/renewal
+      #     ln -s ${CERT_PATH}/fullchain1.pem ${LIVE_PATH}/fullchain.pem
+      #     ln -s ${CERT_PATH}/privkey1.pem ${LIVE_PATH}/privkey.pem
+      #     ln -s ${CERT_PATH}/chain1.pem ${LIVE_PATH}/chain.pem
+      #     ln -s ${CERT_PATH}/cert1.pem ${LIVE_PATH}/cert.pem
+      # - name: debug
+      #   run: |
+      #     first_domain=$(echo ${{ secrets.CERTBOT_DOMAINS }} | cut -d',' -f1)
+      #     echo "::add-mask::${first_domain}"
+      #     find certbot-config/live -ls
+      #     find certbot-config/archive -ls
       - name: Generate certificate
         uses: docker://certbot/dns-route53
         with:
@@ -65,8 +66,9 @@ jobs:
           PRIVATE_KEY=$(cat ${CERT_PATH}/privkey1.pem)
           CERTIFICATE_CHAIN=$(cat ${CERT_PATH}/chain1.pem)
           CERTIFICATE=$(cat ${CERT_PATH}/cert1.pem)
-          SECRET_STRING=$(jq -n --arg cert "$CERTIFICATE" --arg key "$PRIVATE_KEY" --arg chain "$CERTIFICATE_CHAIN" --arg fullchain "$FULLCHAIN" \
-            '{"certificate": $cert, "private_key": $key, "certificate_chain": $chain, "fullchain": $fullchain}')
+          RENEWAL=$(can certbot-config/renewal)
+          SECRET_STRING=$(jq -n --arg cert "$CERTIFICATE" --arg key "$PRIVATE_KEY" --arg chain "$CERTIFICATE_CHAIN" --arg fullchain "$FULLCHAIN"  --arg renewal "$RENEWAL" \
+          '{"certificate": $cert, "private_key": $key, "certificate_chain": $chain, "fullchain": $fullchain}, "renewal": ${renewal}')
           aws secretsmanager update-secret --secret-id ${first_domain}-cert --secret-string "$SECRET_STRING"
       - name: Shred certificates
         run: shred -u certbot-config/archive/*/*

--- a/.github/workflows/dns.yaml
+++ b/.github/workflows/dns.yaml
@@ -66,7 +66,7 @@ jobs:
           PRIVATE_KEY=$(cat ${CERT_PATH}/privkey1.pem)
           CERTIFICATE_CHAIN=$(cat ${CERT_PATH}/chain1.pem)
           CERTIFICATE=$(cat ${CERT_PATH}/cert1.pem)
-          RENEWAL=$(can certbot-config/renewal)
+          RENEWAL=$(cat certbot-config/renewal)
           SECRET_STRING=$(jq -n --arg cert "$CERTIFICATE" --arg key "$PRIVATE_KEY" --arg chain "$CERTIFICATE_CHAIN" --arg fullchain "$FULLCHAIN"  --arg renewal "$RENEWAL" \
           '{"certificate": $cert, "private_key": $key, "certificate_chain": $chain, "fullchain": $fullchain}, "renewal": ${renewal}')
           aws secretsmanager update-secret --secret-id ${first_domain}-cert --secret-string "$SECRET_STRING"

--- a/.github/workflows/dns.yaml
+++ b/.github/workflows/dns.yaml
@@ -43,7 +43,7 @@ jobs:
         uses: docker://certbot/dns-route53
         with:
           args: >
-            certonly --non-interactive --agree-tos --email ${{ secrets.CERTBOT_EMAIL }} --dns-route53 --domains ${{ secrets.CERTBOT_DOMAINS }} --config-dir /github/workspace/certbot-config --work-dir /github/workspace/certbot-work --logs-dir /github/workspace/certbot-logs --keep-until-expiring --quiet
+            certonly --non-interactive --agree-tos --email ${{ secrets.CERTBOT_EMAIL }} --dns-route53 --domains ${{ secrets.CERTBOT_DOMAINS }} --config-dir /github/workspace/certbot-config --work-dir /github/workspace/certbot-work --logs-dir /github/workspace/certbot-logs --keep-until-expiring --quiet --test-cert
 
       - name: Fix file permissions
         uses: docker://certbot/dns-route53

--- a/.github/workflows/dns.yaml
+++ b/.github/workflows/dns.yaml
@@ -23,12 +23,12 @@ jobs:
       #     SECRET_STRING=$(aws secretsmanager get-secret-value --secret-id ${first_domain}-cert --query SecretString --output text)
       #     CERT_PATH="certbot-config/archive/${first_domain}"
       #     LIVE_PATH="certbot-config/live/${first_domain}"
-      #     mkdir -p ${CERT_PATH} ${LIVE_PATH}
+      #     mkdir -p ${CERT_PATH} ${LIVE_PATH} certbot-config/renewal
       #     echo "$SECRET_STRING" | jq -r .fullchain > ${CERT_PATH}/fullchain1.pem
       #     echo "$SECRET_STRING" | jq -r .private_key > ${CERT_PATH}/privkey1.pem
       #     echo "$SECRET_STRING" | jq -r .certificate_chain > ${CERT_PATH}/chain1.pem
       #     echo "$SECRET_STRING" | jq -r .certificate > ${CERT_PATH}/cert1.pem
-      #     echo "$SECRET_STRING" | jq -r .renewal > certbot-config/renewal
+      #     echo "$SECRET_STRING" | jq -r .renewal > certbot-config/renewal/${first_domain}.conf
       #     ln -s ${CERT_PATH}/fullchain1.pem ${LIVE_PATH}/fullchain.pem
       #     ln -s ${CERT_PATH}/privkey1.pem ${LIVE_PATH}/privkey.pem
       #     ln -s ${CERT_PATH}/chain1.pem ${LIVE_PATH}/chain.pem
@@ -63,11 +63,12 @@ jobs:
           first_domain=$(echo ${{ secrets.CERTBOT_DOMAINS }} | cut -d',' -f1)
           echo "::add-mask::${first_domain}-cert"
           CERT_PATH="certbot-config/archive/${first_domain}"
+          RENEWAL_PATH="certbot-config/renewal"
           FULLCHAIN=$(cat ${CERT_PATH}/fullchain1.pem)
           PRIVATE_KEY=$(cat ${CERT_PATH}/privkey1.pem)
           CERTIFICATE_CHAIN=$(cat ${CERT_PATH}/chain1.pem)
           CERTIFICATE=$(cat ${CERT_PATH}/cert1.pem)
-          RENEWAL=$(cat certbot-config/renewal)
+          RENEWAL=$(cat ${RENEWAL_PATH}/${first_domain}.conf)
           SECRET_STRING=$(jq -n --arg cert "$CERTIFICATE" --arg key "$PRIVATE_KEY" --arg chain "$CERTIFICATE_CHAIN" --arg fullchain "$FULLCHAIN"  --arg renewal "$RENEWAL" \
           '{"certificate": $cert, "private_key": $key, "certificate_chain": $chain, "fullchain": $fullchain}, "renewal": ${renewal}')
           aws secretsmanager update-secret --secret-id ${first_domain}-cert --secret-string "$SECRET_STRING"

--- a/README.md
+++ b/README.md
@@ -131,9 +131,10 @@ In order to have a functioning pipeline and make it easier for others I have som
 
 ### Secrets
 
-| Name                   | Description                                                          |
-| ---------------------- | -------------------------------------------------------------------- |
-| ANSIBLE_EXTRA_VAR_JSON | json document for extra vars, holds op_connect_token and op_vault_id |
+| Name                     | Description                                                          |
+| ------------------------ | -------------------------------------------------------------------- |
+| ANSIBLE_EXTRA_VAR_JSON   | json document for extra vars, holds op_connect_token and op_vault_id |
+| OP_SERVICE_ACCOUNT_TOKEN | 1password Service Account Auth Token: GitHub Actions                 |
 
 ______________________________________________________________________
 

--- a/ansible/galaxy.yaml
+++ b/ansible/galaxy.yaml
@@ -2,11 +2,14 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/requirements.json
 roles:
   - name: artis3n.tailscale
+    version: "5.0.1"
   - name: xolyu.mariadb
+    version: "0.2.0"
+  - name: hussainweb.chezmoi
 collections:
   - name: community.general
-    version: ">=10.1.0"
+    version: "10.5.0"
   - name: https://github.com/stoneydavis/ansible-collection-pterodactyl.git
     type: git
   - name: community.docker
-  - name: onepassword.connect
+    version: "4.5.2"

--- a/ansible/galaxy.yaml
+++ b/ansible/galaxy.yaml
@@ -1,8 +1,6 @@
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/requirements.json
 roles:
-  - name: artis3n.tailscale
-    version: "5.0.1"
   - name: xolyu.mariadb
     version: "0.2.0"
   - name: hussainweb.chezmoi
@@ -13,3 +11,5 @@ collections:
     type: git
   - name: community.docker
     version: "4.5.2"
+  - name: artis3n.tailscale
+    version: "1.0.1"

--- a/ansible/group_vars/all.yaml
+++ b/ansible/group_vars/all.yaml
@@ -1,7 +1,7 @@
 ---
 # yaml-language server: $schema=https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/vars.json
 # version increment: 1 # this is being used to trigger the changed files check in CI
-k3s_git_repo: git@github.com:raypappa/homelab.git
+k3s_git_repo: https://github.com/raypappa/homelab.git
 k3s_server_location: /var/lib/rancher/k3s
 k3s_env_tz: America/Los_Angeles
 k3s_env_puid: "1000"
@@ -11,9 +11,13 @@ k3s_version: v1.32.1+k3s1
 ansible_connection: ssh
 argocd_version: 2.11.5
 systemd_dir: /etc/systemd/system
-master_ip: "{{ hostvars[groups[hostvars[inventory_hostname].group_names[0]][0]]['ansible_host'] }}"
 extra_server_args: ""
 extra_agent_args: ""
 ansible_user: root
 tailscale_authkey: "{{ lookup('env', 'HEADSCALE_KEY') }}"
 users: ['root', 'stoney']
+# renovate: datasource=github-releases depName=helm/helm
+helm_version: 3.17.3
+helm_arch:
+  x86_64: amd64
+  aarch64: arm64

--- a/ansible/group_vars/dev_k8s_cluster.yaml
+++ b/ansible/group_vars/dev_k8s_cluster.yaml
@@ -1,5 +1,4 @@
 ---
 # yaml-language server: $schema=https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/vars.json
 k3s_cloudflare_domain_name: devfieldsofbears.com
-master_ip: "{{ hostvars[groups['dev_k8s_controlplane'][0]]['ansible_host'] | default(groups['dev_k8s_controlplane'][0]) }}"
 singleton_host: "{{ groups['dev_k8s_controlplane'][0] }}"

--- a/ansible/group_vars/prod_k8s_cluster.yaml
+++ b/ansible/group_vars/prod_k8s_cluster.yaml
@@ -1,6 +1,5 @@
 ---
 # yaml-language server: $schema=https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/vars.json
 k3s_cloudflare_domain_name: fieldsofbears.com
-master_ip: "{{ hostvars[groups['prod_k8s_controlplane'][0]]['ansible_host'] | default(groups['prod_k8s_controlplane'][0]) }}"
 singleton_host: "{{ groups['prod_k8s_controlplane'][0] }}"
 git_sub_path: "main"

--- a/ansible/homelab.yaml
+++ b/ansible/homelab.yaml
@@ -10,24 +10,27 @@
     - common_critical
     - common
 - name: Production Kubernetes Cluster
+  order: sorted
   hosts:
     - prod_k8s_cluster
   become: true
   roles:
     - k3s-prereq
 - name: Production Kubernetes Control Plane
+  order: sorted
   hosts:
     - prod_k8s_controlplane
   roles:
     - k3s-controlplane
 - name: Production Kubernetes Nodes
+  order: sorted
   hosts:
     - prod_k8s_nodes
   roles:
     - k3s-nodes
 - name: Faerun Public
   hosts:
-    - puma.stoneydavis.lan
+    - kubernetes-node-0001.stoneydavis.local
   roles:
     - faerun-public
   tags:

--- a/ansible/hosts
+++ b/ansible/hosts
@@ -6,9 +6,9 @@
     # warthog.stoneydavis.local:
 prod_k8s_controlplane:
   hosts:
-    kubernetes-node-0003.stoneydavis.local:
     kubernetes-node-0001.stoneydavis.local:
     kubernetes-node-0002.stoneydavis.local:
+    kubernetes-node-0003.stoneydavis.local:
 # Non-Controlplane nodes
 # prod_k8s_nodes:
 #   hosts:

--- a/ansible/hosts
+++ b/ansible/hosts
@@ -1,24 +1,21 @@
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/inventory.json
-faerun:
-  hosts:
-    puma.stoneydavis.local:
-    panda.stoneydavis.local:
-    # warthog.stoneydavis.stoneydavis.local:
+# faerun:
+#   hosts:
+    # panda.stoneydavis.local:
+    # warthog.stoneydavis.local:
 prod_k8s_controlplane:
   hosts:
     kubernetes-node-0003.stoneydavis.local:
     kubernetes-node-0001.stoneydavis.local:
     kubernetes-node-0002.stoneydavis.local:
-prod_k8s_nodes:
-  hosts:
-    kubernetes-node-0003.stoneydavis.local:
-    kubernetes-node-0001.stoneydavis.local:
-    kubernetes-node-0002.stoneydavis.local:
+# Non-Controlplane nodes
+# prod_k8s_nodes:
+#   hosts:
 prod_k8s_cluster:
   children:
     prod_k8s_controlplane:
-    prod_k8s_nodes:
+    # prod_k8s_nodes:
 # games:
 #   hosts:
 #     bob:
@@ -30,7 +27,7 @@ game_server:
     panda.stoneydavis.local:
 # dev_k8s_controlplane:
 #   hosts:
-#     warthog.stoneydavis.stoneydavis.local:
+#     warthog.stoneydavis.local:
 # dev_k8s_nodes:
 #   hosts:
 # dev_k8s_cluster:
@@ -39,6 +36,6 @@ game_server:
 #     dev_k8s_nodes:
 nfs_server:
   hosts:
-    puma.stoneydavis.local:
+    kubernetes-node-0001.stoneydavis.local:
       nfs_server_export_dirs:
         - /library

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -86,7 +86,7 @@
   loop: "{{ users }}"
 # - name: Install tailscale
 #   ansible.builtin.include_role:
-#     name: artis3n.tailscale
+#     name: artis3n.tailscale.machine
 - name: Set hostname if specified
   become: true
   when: hostname is defined

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/ansible.json#/$defs/tasks
 - name: Get my public IP
   community.general.ipify_facts:
 - name: Ensure that Bookworm /etc/apt/sources.list is sane

--- a/ansible/roles/common/tasks/user.yaml
+++ b/ansible/roles/common/tasks/user.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/ansible.json#/$defs/tasks
 # vim: filetype=ansible.yaml
 - name: Create a configured account for "{{ user }}"
   become: true
@@ -7,26 +8,11 @@
     shell: /bin/bash
     groups: libvirt, dialout, audio, video
     append: true
-- name: Ensure bare dotfile repo is present for "{{ user }}"
-  become_user: "{{ user }}"
-  become: true
-  ansible.builtin.git:
-    dest: ~/.cfg
-    repo: https://github.com/raypappa/dotfiles.git
-    bare: true
-    update: true
-- name: Ensure the config repo is checked out for "{{ user }}"
-  become_user: "{{ user }}"
-  become: true
-  ansible.builtin.command: # noqa: command-instead-of-module
-    cmd: git --git-dir=$HOME/.cfg/ --work-tree=$HOME checkout main --force
-  args:
-    creates: ~/.zshrc
-- name: Ensure config repo is up to date for "{{ user }}"
-  become_user: "{{ user }}"
-  become: true
-  ansible.builtin.command: # noqa: no-changed-when command-instead-of-module
-    cmd: git --git-dir=$HOME/.cfg/ --work-tree=$HOME pull --force
+# - name: Chezmoi user
+#   ansible.builtin.import_role:
+#     name: hussainweb.chezmoi
+#   vars:
+#     chezmoi_init_url: "https://github.com/raypappa/chezmoi-dotfiles.git"
 - name: Create .ssh dir if it doesn't exist for "{{ user }}"
   become: true
   become_user: "{{ user }}"

--- a/ansible/roles/common_critical/tasks/main.yaml
+++ b/ansible/roles/common_critical/tasks/main.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/ansible.json#/$defs/tasks
 # vim: filetype=ansible.yaml
 - name: Ensure that no Bullseye hosts remain
   ansible.builtin.fail:

--- a/ansible/roles/common_reboot/tasks/main.yaml
+++ b/ansible/roles/common_reboot/tasks/main.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/ansible.json#/$defs/tasks
 # vim: filetype=ansible.yaml
 - name: Reboot if update has requested it
   ansible.builtin.stat:

--- a/ansible/roles/faerun-public/tasks/main.yml
+++ b/ansible/roles/faerun-public/tasks/main.yml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/ansible.json#/$defs/tasks
 - name: Get my public IP
   community.general.ipify_facts:
 - name: Set R53 Hosted Zone Record for Puma
@@ -8,7 +9,7 @@
     record: puma.stoneydavis.com
     type: A
     ttl: 7200
-    value: "{{ hostvars['puma.stoneydavis.lan']['ansible_facts']['ipify_public_ip'] }}"
+    value: "{{ hostvars['kubernetes-node-0001.stoneydavis.local']['ansible_facts']['ipify_public_ip'] }}"
     overwrite: true
   delegate_to: localhost
 - name: Set R53 Hosted Zone Record for Panda
@@ -18,6 +19,6 @@
     record: panda.stoneydavis.com
     type: A
     ttl: 7200
-    value: "{{ hostvars['puma.stoneydavis.lan']['ansible_facts']['ipify_public_ip'] }}"
+    value: "{{ hostvars['kubernetes-node-0001.stoneydavis.local']['ansible_facts']['ipify_public_ip'] }}"
     overwrite: true
   delegate_to: localhost

--- a/ansible/roles/k3s-controlplane/tasks/main.yml
+++ b/ansible/roles/k3s-controlplane/tasks/main.yml
@@ -1,10 +1,24 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/ansible.json#/$defs/tasks
 - name: Download and install ArgoCD CLI
   become: true
   ansible.builtin.get_url:
     url: https://github.com/argoproj/argo-cd/releases/download/v{{ argocd_version }}/argocd-linux-amd64
     dest: /usr/local/bin/argocd
     mode: "0555"
+- name: Download and install Helm
+  become: true
+  ansible.builtin.unarchive:
+    src: https://get.helm.sh/helm-v{{ helm_version }}-linux-{{ helm_arch[ansible_architecture] }}.tar.gz
+    remote_src: true
+    extra_opts:
+      - --strip-components=1
+    include:
+      - linux-{{ helm_arch[ansible_architecture] }}/helm
+    mode: "0555"
+    owner: root
+    group: root
+    dest: /usr/local/bin
 - name: Setup Cluster Singleton
   ansible.builtin.import_tasks: singleton.yml
   run_once: true

--- a/ansible/roles/k3s-controlplane/tasks/singleton.yml
+++ b/ansible/roles/k3s-controlplane/tasks/singleton.yml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/ansible.json#/$defs/tasks
 # The singleton is any already running k3s controlplane node.  Mostly we
 # just need to have the correct node token to use on any other control
 # plane node, because we initialize everything on the first one and then
@@ -7,54 +8,6 @@
 #
 # Otherwise they won't be able to communicate and you'd have three
 # isolated control planes, not a single HA control plane.
-- name: Get B2 endpoint
-  field_info:
-    token: "{{ op_connect_token }}"
-    item: backblaze-etcd
-    field: endpoint
-    vault: "{{ op_vault_id }}"
-  no_log: true
-  register: b2_s3_endpoint
-- name: Get B2 access key
-  field_info:
-    token: "{{ op_connect_token }}"
-    item: backblaze-etcd
-    field: access_key
-    vault: "{{ op_vault_id }}"
-  no_log: true
-  register: b2_s3_access_key
-- name: Get B2 secret key
-  field_info:
-    token: "{{ op_connect_token }}"
-    item: backblaze-etcd
-    field: secret_key
-    vault: "{{ op_vault_id }}"
-  no_log: true
-  register: b2_s3_secret_key
-- name: Get B2 bucket
-  field_info:
-    token: "{{ op_connect_token }}"
-    item: backblaze-etcd
-    field: bucket
-    vault: "{{ op_vault_id }}"
-  no_log: true
-  register: b2_s3_bucket
-- name: Get B2 region
-  field_info:
-    token: "{{ op_connect_token }}"
-    item: backblaze-etcd
-    field: region
-    vault: "{{ op_vault_id }}"
-  no_log: true
-  register: b2_s3_region
-- name: Get B2 folder
-  field_info:
-    token: "{{ op_connect_token }}"
-    item: backblaze-etcd
-    field: folder
-    vault: "{{ op_vault_id }}"
-  no_log: true
-  register: b2_s3_folder
 - name: Create Primary Deploy Key
   become: false
   community.crypto.openssh_keypair:
@@ -73,14 +26,14 @@
   ansible.builtin.file:
     path: /etc/rancher/k3s/
     state: directory
-    mode: "0755"
+    mode: "0700"
 - name: Copy Jinja template
   ansible.builtin.template:
     src: singleton.config.yaml.j2
     dest: /etc/rancher/k3s/config.yaml
     owner: root
     group: root
-    mode: "0644"
+    mode: "0600"
 - name: Copy K3s service file
   register: k3s_service
   ansible.builtin.template:
@@ -95,7 +48,7 @@
     dest: /etc/rancher/k3s/kubelet.config
     owner: root
     group: root
-    mode: "0644"
+    mode: "0600"
 - name: Enable and check K3s service
   any_errors_fatal: true
   ansible.builtin.systemd:
@@ -156,35 +109,52 @@
 - name: Create ArgoCD NameSpace
   become: false
   kubernetes.core.k8s:
-    host: https://{{ inventory_hostname }}:6443
+    host: https://localhost:6443
     name: argocd
     kind: Namespace
     state: present
-- name: Apply ArgoCD Kustomize
-  kubernetes.core.k8s:
-    host: https://{{ inventory_hostname }}:6443
-    definition: "{{ lookup('kubernetes.core.kustomize', dir='https://github.com/raypappa/homelab.git/kubernetes/{{git_sub_path}}/bootstrap/argocd', enable_helm=True) }}"
-  when: "{{ query('kubernetes.core.k8s', host='https://{{inventory_hostname}}:6443', kind='Deployment', namespace='argocd', resource_name='argocd-server') | length < 1}}"
+- name: Wait for k3s to stabilize
+  ansible.builtin.wait_for:
+    port: 6443
+    delay: 10
+    timeout: 300
+    state: started
+- name: Apply ArgoCD Kustomize # this is not the right way to do it but using kubernetes.core.k8s was failing for some reason.
+  ansible.builtin.shell:
+    cmd: >-
+      k3s kubectl kustomize --enable-helm=True https://github.com/raypappa/homelab.git/kubernetes/{{ git_sub_path }}/bootstrap/argocd | k3s kubectl apply -f -
+- name: Wait for ArgoCD to be ready
+  become: false
+  retries: 10
+  until: argocd_server_check is not failed
+  delay: 5
+  register: argocd_server_check
+  kubernetes.core.k8s_info:
+    host: https://localhost:6443
+    label_selectors:
+      - name = argocd-repo-server
+    kind: pod
+    namespace: argocd
 - name: Read kubeconfig
   ansible.builtin.slurp:
-    src: "{{(ansible_user_dir, '.kube', 'config') | path_join}}"
+    src: "{{ (ansible_user_dir, '.kube', 'config') | path_join }}"
   register: kubeconfig_b64
 - name: Parse kubeconfig
   ansible.builtin.set_fact:
     kubeconfig: "{{ kubeconfig_b64['content'] | b64decode | from_yaml }}"
 - name: First Context in kubeconfig
   ansible.builtin.set_fact:
-    kubeconfig_contexts: "{{ [kubeconfig.contexts[0]|combine({'context': {'namespace': 'argocd'}}, recursive=True)] | union(kubeconfig.contexts[1:]) }}"
+    kubeconfig_contexts: "{{ [kubeconfig.contexts[0]|combine({ 'context': {'namespace': 'argocd' }}, recursive=True)] | union(kubeconfig.contexts[1:]) }}"
 - name: Set kubectl current context namespace to argocd
   ansible.builtin.copy:
-    dest: "{{(ansible_user_dir, '.kube', 'config') | path_join}}"
+    dest: "{{ (ansible_user_dir, '.kube', 'config') | path_join }}"
     content: "{{ kubeconfig|combine({'contexts': kubeconfig_contexts})|ansible.builtin.to_nice_yaml}}"
     owner: "{{ ansible_user }}"
     mode: u=rw,g=,o=
 - name: Configure ArgoCD for the cluster
   ansible.builtin.command:
     cmd: argocd login --core
-    creates: "{{(ansible_user_dir, '.config','argocd','config') | path_join}}"
+    creates: "{{ (ansible_user_dir, '.config','argocd','config') | path_join }}"
 - name: List Configured Repositories in ArgoCD
   ansible.builtin.command: >-
     argocd repo list -o json
@@ -193,5 +163,5 @@
 - name: Configure ArgoCD with SSH Key
   become: true
   ansible.builtin.command: >-
-    argocd repo add "{{ k3s_git_repo }}" --ssh-private-key-path "{{(ansible_user_dir, '.ssh','id_ed25519_backup') | path_join}}"
+    argocd repo add "{{ k3s_git_repo }}"
   when: argocd_repos.stdout.find(k3s_git_repo)

--- a/ansible/roles/k3s-controlplane/templates/config.yaml.j2
+++ b/ansible/roles/k3s-controlplane/templates/config.yaml.j2
@@ -4,3 +4,5 @@ server: https://{{ singleton_host }}:6443
 disable:
   - servicelb
   - traefik
+tls-san:
+  - {{ inventory_hostname }}

--- a/ansible/roles/k3s-controlplane/templates/singleton.config.yaml.j2
+++ b/ansible/roles/k3s-controlplane/templates/singleton.config.yaml.j2
@@ -11,4 +11,5 @@ etcd-s3-bucket: "{{ lookup("community.general.onepassword","backblaze-etcd", fie
 etcd-s3-region: "{{ lookup("community.general.onepassword","backblaze-etcd", field="region", service_account_token=op_sa_token, subdomain="my", vault=op_vault_id) }}"
 etcd-s3-folder: "{{ lookup("community.general.onepassword","backblaze-etcd", field="folder", service_account_token=op_sa_token, subdomain="my", vault=op_vault_id) }}"
 etcd-s3: true
-tls-san: "{{ inventory_hostname }}"
+tls-san:
+  - {{ inventory_hostname }}

--- a/ansible/roles/k3s-controlplane/templates/singleton.config.yaml.j2
+++ b/ansible/roles/k3s-controlplane/templates/singleton.config.yaml.j2
@@ -4,10 +4,11 @@ disable:
   - traefik
 etcd-snapshot-retention: 60
 etcd-snapshot-schedule-cron: 0 */12 * * *
-etcd-s3-endpoint: "{{ b2_s3_endpoint.field.value }}"
-etcd-s3-access-key: "{{ b2_s3_access_key.field.value }}"
-etcd-s3-secret-key: "{{ b2_s3_secret_key.field.value }}"
-etcd-s3-bucket: "{{ b2_s3_bucket.field.value }}"
-etcd-s3-region: "{{ b2_s3_region.field.value }}"
-etcd-s3-folder: "{{ b2_s3_folder.field.value }}"
+etcd-s3-endpoint: "{{ lookup("community.general.onepassword","backblaze-etcd", field="endpoint", service_account_token=op_sa_token, subdomain="my", vault=op_vault_id) }}"
+etcd-s3-access-key: "{{ lookup("community.general.onepassword","backblaze-etcd", field="access_key", service_account_token=op_sa_token, subdomain="my", vault=op_vault_id) }}"
+etcd-s3-secret-key: "{{ lookup("community.general.onepassword","backblaze-etcd", field="secret_key", service_account_token=op_sa_token, subdomain="my", vault=op_vault_id) }}"
+etcd-s3-bucket: "{{ lookup("community.general.onepassword","backblaze-etcd", field="bucket", service_account_token=op_sa_token, subdomain="my", vault=op_vault_id) }}"
+etcd-s3-region: "{{ lookup("community.general.onepassword","backblaze-etcd", field="region", service_account_token=op_sa_token, subdomain="my", vault=op_vault_id) }}"
+etcd-s3-folder: "{{ lookup("community.general.onepassword","backblaze-etcd", field="folder", service_account_token=op_sa_token, subdomain="my", vault=op_vault_id) }}"
 etcd-s3: true
+tls-san: "{{ inventory_hostname }}"

--- a/ansible/roles/k3s-nodes/tasks/cluster.yml
+++ b/ansible/roles/k3s-nodes/tasks/cluster.yml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/ansible.json#/$defs/tasks
 # vim filetype=ansible.yaml
 # NON-SINGLETON cluster - 2nd and after HA masters.
 

--- a/ansible/roles/k3s-nodes/tasks/main.yml
+++ b/ansible/roles/k3s-nodes/tasks/main.yml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/ansible.json#/$defs/tasks
 - name: Setup Cluster Node
   ansible.builtin.import_tasks: cluster.yml
   become: true

--- a/ansible/roles/k3s-prereq/tasks/main.yml
+++ b/ansible/roles/k3s-prereq/tasks/main.yml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/ansible.json#/$defs/tasks
 - name: Example from an Ansible Playbook
   ansible.builtin.ping:
 - name: Enable IPv4 forwarding

--- a/ansible/roles/nfs_server/tasks/main.yaml
+++ b/ansible/roles/nfs_server/tasks/main.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/ansible.json#/$defs/tasks
 - name: Increase max inotify watches
   ansible.posix.sysctl:
     name: fs.inotify.max_user_instances


### PR DESCRIPTION
fixing issues with the ansible for bootstrapping the cluster for multi-node controlplanes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automated installation of Helm during Kubernetes control plane setup.
  - Introduced new role for managing user dotfiles with Chezmoi.

- **Enhancements**
  - Updated Ansible roles and collections to use specific versions for improved reliability.
  - Switched secret management for etcd S3 credentials to use secure vault lookups.
  - Improved playbook and inventory structure, including sorted execution order and updated host assignments.
  - Added TLS Subject Alternative Name configuration for Kubernetes control plane.

- **Bug Fixes**
  - Refined DNS update logic to use correct host references.

- **Chores**
  - Added schema validation directives to multiple Ansible YAML files for better editor support.
  - Updated documentation to reflect new required secrets for GitHub Actions.
  - Updated spell-check dictionaries with relevant terms.

- **Cleanup**
  - Removed deprecated variables and tasks, including legacy Git-based dotfiles management and unused host groups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->