### PR TITLE
fix(kubernetes): use home-operations images over onedr0p

### DIFF
--- a/.github/workflows/kustomize.yaml
+++ b/.github/workflows/kustomize.yaml
@@ -22,5 +22,7 @@ jobs:
           version: ${{ vars.TASK_VERSION}}
       - name: Kustomize Version
         run: kustomize version
+      - name: Helm version
+        run: helm version
       - name: Kustomize It!
         run: task build:kustomize

--- a/.github/workflows/kustomize.yaml
+++ b/.github/workflows/kustomize.yaml
@@ -12,6 +12,10 @@ jobs:
       - uses: syntaqx/setup-kustomize@v1
         with:
           kustomize-version: 5.3.0
+      - uses: azure/setup-helm@v4.3.0
+        with:
+          version: 3.17.0
+        id: install
       - name: arduino/setup-task
         uses: arduino/setup-task@v2.0.0
         with:

--- a/kubernetes/main/apps/downloads/prowlarr/kustomization.yaml
+++ b/kubernetes/main/apps/downloads/prowlarr/kustomization.yaml
@@ -11,7 +11,7 @@ helmCharts:
     valuesFile: cloudflare-values.yaml
   - name: app-template
     includeCRDs: true
-    repo: https://bjw-s.github.io/helm-charts
+    repo: https://bjw-s-labs.github.io/helm-charts
     namespace: prowlarr
     releaseName: prowlarr
     version: 3.7.1

--- a/kubernetes/main/apps/downloads/prowlarr/values.yaml
+++ b/kubernetes/main/apps/downloads/prowlarr/values.yaml
@@ -15,8 +15,8 @@ controllers:
     containers:
       app:
         image:
-          repository: ghcr.io/onedr0p/prowlarr-nightly
-          # renovate: datasource=docker depName=ghcr.io/onedr0p/prowlarr-nightly
+          repository: ghcr.io/home-operations/prowlarr-nightly
+          # renovate: datasource=docker depName=ghcr.io/home-operations/prowlarr-nightly
           tag: 1.32.0.4978@sha256:2e591adeb3bca0df19b28056fb02749bd9ea434a704fda1574be0316856402f7
           pullPolicy: IfNotPresent
         env:

--- a/kubernetes/main/apps/downloads/radarr/kustomization.yaml
+++ b/kubernetes/main/apps/downloads/radarr/kustomization.yaml
@@ -11,7 +11,7 @@ helmCharts:
     valuesFile: cloudflare-values.yaml
   - name: app-template
     includeCRDs: true
-    repo: https://bjw-s.github.io/helm-charts
+    repo: https://bjw-s-labs.github.io/helm-charts
     namespace: radarr
     releaseName: radarr
     version: 3.7.1

--- a/kubernetes/main/apps/downloads/radarr/values.yaml
+++ b/kubernetes/main/apps/downloads/radarr/values.yaml
@@ -13,8 +13,8 @@ controllers:
     containers:
       main:
         image:
-          repository: ghcr.io/onedr0p/radarr
-          # renovate: datasource=docker depName=ghcr.io/onedr0p/radarr
+          repository: ghcr.io/home-operations/radarr
+          # renovate: datasource=docker depName=ghcr.io/home-operations/radarr
           tag: 5.18.4
           pullPolicy: IfNotPresent
         env:

--- a/kubernetes/main/apps/downloads/readarr/kustomization.yaml
+++ b/kubernetes/main/apps/downloads/readarr/kustomization.yaml
@@ -11,7 +11,7 @@ helmCharts:
     valuesFile: cloudflare-values.yaml
   - name: app-template
     includeCRDs: true
-    repo: https://bjw-s.github.io/helm-charts
+    repo: https://bjw-s-labs.github.io/helm-charts
     namespace: readarr
     releaseName: readarr
     version: 3.7.1

--- a/kubernetes/main/apps/downloads/readarr/values.yaml
+++ b/kubernetes/main/apps/downloads/readarr/values.yaml
@@ -14,8 +14,8 @@ controllers:
     containers:
       app:
         image:
-          repository: ghcr.io/onedr0p/readarr-nightly
-          # renovate: datasource=docker depName=ghcr.io/onedr0p/readarr-nightly
+          repository: ghcr.io/home-operations/readarr-nightly
+          # renovate: datasource=docker depName=ghcr.io/home-operations/readarr-nightly
           tag: 0.4.0
           pullPolicy: IfNotPresent
         env:

--- a/kubernetes/main/apps/downloads/recyclarr/kustomization.yaml
+++ b/kubernetes/main/apps/downloads/recyclarr/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: recyclarr
 helmCharts:
   - name: app-template
     includeCRDs: true
-    repo: https://bjw-s.github.io/helm-charts
+    repo: https://bjw-s-labs.github.io/helm-charts
     namespace: recyclarr
     releaseName: recyclarr
     version: 3.7.1

--- a/kubernetes/main/apps/downloads/rtorrent/kustomization.yaml
+++ b/kubernetes/main/apps/downloads/rtorrent/kustomization.yaml
@@ -11,7 +11,7 @@ helmCharts:
     valuesFile: cloudflare-values.yaml
   - name: app-template
     includeCRDs: true
-    repo: https://bjw-s.github.io/helm-charts
+    repo: https://bjw-s-labs.github.io/helm-charts
     namespace: rtorrent
     releaseName: rtorrent
     version: 3.7.1

--- a/kubernetes/main/apps/downloads/sonarr/kustomization.yaml
+++ b/kubernetes/main/apps/downloads/sonarr/kustomization.yaml
@@ -4,7 +4,7 @@ kind: Kustomization
 helmCharts:
   - name: app-template
     # Ugh please replace this with using bjw-s
-    repo: https://bjw-s.github.io/helm-charts
+    repo: https://bjw-s-labs.github.io/helm-charts
     version: 3.7.1
     namespace: sonarr
     releaseName: sonarr

--- a/kubernetes/main/apps/downloads/sonarr/sonarr-values.yaml
+++ b/kubernetes/main/apps/downloads/sonarr/sonarr-values.yaml
@@ -18,8 +18,8 @@ controllers:
     containers:
       app:
         image:
-          repository: ghcr.io/onedr0p/sonarr-develop
-          # renovate: datasource=docker depName=ghcr.io/onedr0p/sonarr-develop
+          repository: ghcr.io/home-operations/sonarr-develop
+          # renovate: datasource=docker depName=ghcr.io/home-operations/sonarr-develop
           tag: 4.0.13
         env:
           COMPlus_EnableDiagnostics: "0"

--- a/kubernetes/main/apps/downloads/unpackerr/kustomization.yaml
+++ b/kubernetes/main/apps/downloads/unpackerr/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: unpackerr
 helmCharts:
   - name: app-template
     includeCRDs: true
-    repo: https://bjw-s.github.io/helm-charts
+    repo: https://bjw-s-labs.github.io/helm-charts
     namespace: unpackerr
     releaseName: unpackerr
     version: 3.7.1

--- a/kubernetes/main/apps/downloads/whisparr/kustomization.yaml
+++ b/kubernetes/main/apps/downloads/whisparr/kustomization.yaml
@@ -11,7 +11,7 @@ helmCharts:
     valuesFile: cloudflare-values.yaml
   - name: app-template
     includeCRDs: true
-    repo: https://bjw-s.github.io/helm-charts
+    repo: https://bjw-s-labs.github.io/helm-charts
     namespace: whisparr
     releaseName: whisparr
     version: 3.7.1

--- a/kubernetes/main/apps/media/jellyfin/kustomization.yaml
+++ b/kubernetes/main/apps/media/jellyfin/kustomization.yaml
@@ -3,7 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 helmCharts:
   - name: app-template
-    repo: https://bjw-s.github.io/helm-charts
+    repo: https://bjw-s-labs.github.io/helm-charts
     version: 3.7.1
     namespace: media
     releaseName: jellyfin

--- a/kubernetes/main/apps/media/plex/kustomization.yaml
+++ b/kubernetes/main/apps/media/plex/kustomization.yaml
@@ -3,7 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 helmCharts:
   - name: app-template
-    repo: https://bjw-s.github.io/helm-charts
+    repo: https://bjw-s-labs.github.io/helm-charts
     version: 3.7.1
     namespace: media
     releaseName: plex

--- a/kubernetes/main/apps/media/plex/values.yaml
+++ b/kubernetes/main/apps/media/plex/values.yaml
@@ -19,8 +19,8 @@ controllers:
     containers:
       app:
         image:
-          repository: ghcr.io/onedr0p/plex
-          # renovate: datasource=docker depName=ghcr.io/onedr0p/plex
+          repository: ghcr.io/home-operations/plex
+          # renovate: datasource=docker depName=ghcr.io/home-operations/plex
           tag: 1.41.4.9463-630c9f557
         env:
           PLEX_NO_AUTH_NETWORKS: 172.17.42.0/24

--- a/kubernetes/main/apps/selfhosted/it-tools/kustomization.yaml
+++ b/kubernetes/main/apps/selfhosted/it-tools/kustomization.yaml
@@ -3,7 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 helmCharts:
   - name: app-template
-    repo: https://bjw-s.github.io/helm-charts
+    repo: https://bjw-s-labs.github.io/helm-charts
     version: 3.7.1
     namespace: it-tools
     releaseName: it-tools

--- a/kubernetes/main/apps/selfhosted/joplin/kustomization.yaml
+++ b/kubernetes/main/apps/selfhosted/joplin/kustomization.yaml
@@ -3,7 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 helmCharts:
   - name: app-template
-    repo: https://bjw-s.github.io/helm-charts
+    repo: https://bjw-s-labs.github.io/helm-charts
     version: 3.7.1
     namespace: joplin
     releaseName: joplin

--- a/kubernetes/main/apps/selfhosted/lemonldap/kustomization.yaml
+++ b/kubernetes/main/apps/selfhosted/lemonldap/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: ldap
 helmCharts:
   - name: app-template
     includeCRDs: true
-    repo: https://bjw-s.github.io/helm-charts
+    repo: https://bjw-s-labs.github.io/helm-charts
     namespace: ldap
     releaseName: lemonldap-app
     version: 3.7.1

--- a/kubernetes/main/apps/selfhosted/timetagger/kustomization.yaml
+++ b/kubernetes/main/apps/selfhosted/timetagger/kustomization.yaml
@@ -20,7 +20,7 @@ helmCharts:
             service: "http://timetagger.timetagger.svc.cluster.local:80"
   - name: app-template
     includeCRDs: true
-    repo: https://bjw-s.github.io/helm-charts
+    repo: https://bjw-s-labs.github.io/helm-charts
     namespace: timetagger
     releaseName: timetagger
     version: 3.7.1

--- a/kubernetes/main/apps/selfhosted/wyoming-piper/kustomization.yaml
+++ b/kubernetes/main/apps/selfhosted/wyoming-piper/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: home-assistant
 helmCharts:
   - name: app-template
     includeCRDs: true
-    repo: https://bjw-s.github.io/helm-charts
+    repo: https://bjw-s-labs.github.io/helm-charts
     namespace: home-assistant
     releaseName: piper
     version: 3.7.1

--- a/kubernetes/main/apps/selfhosted/wyoming-whisper/kustomization.yaml
+++ b/kubernetes/main/apps/selfhosted/wyoming-whisper/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: home-assistant
 helmCharts:
   - name: app-template
     includeCRDs: true
-    repo: https://bjw-s.github.io/helm-charts
+    repo: https://bjw-s-labs.github.io/helm-charts
     namespace: home-assistant
     releaseName: whisper
     version: 3.7.1


### PR DESCRIPTION
onedr0p archived their repo and created home-operations instead


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated Docker image repositories for Prowlarr, Radarr, Readarr, Sonarr, and Plex to use a new source.
	- Modified workflow to include Helm installation and version verification steps.
	- Updated Helm chart repository URLs across multiple applications for improved chart sourcing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->