### PR TITLE
fix(github): remove setup-python

### DIFF
--- a/.github/workflows/ansible-scheduled.yaml
+++ b/.github/workflows/ansible-scheduled.yaml
@@ -26,10 +26,6 @@ jobs:
         uses: astral-sh/setup-uv@v6
         with:
           version: "0.5.24"
-      - name: "Set up Python"
-        uses: actions/setup-python@v5
-        with:
-          python-version-file: ".python-version"
       - run: task configure
       - name: Create extra vars file
         run: echo "${{ secrets.ANSIBLE_EXTRA_VAR_JSON}}" > ansible/ansible_extra_vars.json

--- a/.github/workflows/cdk.yaml
+++ b/.github/workflows/cdk.yaml
@@ -57,10 +57,6 @@ jobs:
         uses: astral-sh/setup-uv@v6
         with:
           version: "0.5.24"
-      - name: "Set up Python"
-        uses: actions/setup-python@v5
-        with:
-          python-version-file: ".python-version"
       - name: Setting up CDK
         run: task configure
       - name: Bootstrapping CDK

--- a/.github/workflows/dns.yaml
+++ b/.github/workflows/dns.yaml
@@ -95,10 +95,6 @@ jobs:
         uses: astral-sh/setup-uv@v6
         with:
           version: "0.5.24"
-      - name: "Set up Python"
-        uses: actions/setup-python@v5
-        with:
-          python-version-file: ".python-version"
       - run: task configure
       - name: Setup SSH
         run: |


### PR DESCRIPTION
Removing the step to setup python, since we have uv now, the uv sync should take care of this already


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Removed explicit Python environment setup steps from several GitHub Actions workflows, streamlining the workflow configuration. No changes to workflow logic or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->