### PR TITLE
feat(elasticsearch): add ECK operator and single-node cluster

### DIFF
--- a/kubernetes/main/apps/database/elasticsearch-operator/README.md
+++ b/kubernetes/main/apps/database/elasticsearch-operator/README.md
@@ -1,0 +1,3 @@
+# Elasticsearch Operator
+
+Installs the Elastic Cloud on Kubernetes (ECK) operator from the official Helm chart in cluster-wide mode with CRDs included.

--- a/kubernetes/main/apps/database/elasticsearch-operator/config.json
+++ b/kubernetes/main/apps/database/elasticsearch-operator/config.json
@@ -1,0 +1,9 @@
+{
+  "destNamespace": "elastic-system",
+  "appName": "elasticsearch-operator",
+  "serverSideApply": true,
+  "ignoreDifferences": [],
+  "group": "database",
+  "dependencies": [],
+  "wave": "1"
+}

--- a/kubernetes/main/apps/database/elasticsearch-operator/kustomization.yaml
+++ b/kubernetes/main/apps/database/elasticsearch-operator/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: elastic-system
+helmCharts:
+  - name: eck-operator
+    releaseName: elastic-operator
+    repo: https://helm.elastic.co
+    version: 3.3.2
+    includeCRDs: true

--- a/kubernetes/main/apps/database/elasticsearch/README.md
+++ b/kubernetes/main/apps/database/elasticsearch/README.md
@@ -1,0 +1,3 @@
+# Elasticsearch
+
+Deploys a single-node Elasticsearch cluster using the ECK operator.

--- a/kubernetes/main/apps/database/elasticsearch/cluster.yaml
+++ b/kubernetes/main/apps/database/elasticsearch/cluster.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: elasticsearch.k8s.elastic.co/v1
+kind: Elasticsearch
+metadata:
+  name: elasticsearch
+spec:
+  version: 9.3.3
+  nodeSets:
+    - name: default
+      count: 1
+      config:
+        node.store.allow_mmap: false

--- a/kubernetes/main/apps/database/elasticsearch/config.json
+++ b/kubernetes/main/apps/database/elasticsearch/config.json
@@ -1,0 +1,9 @@
+{
+  "destNamespace": "elastic-system",
+  "appName": "elasticsearch",
+  "serverSideApply": true,
+  "ignoreDifferences": [],
+  "group": "database",
+  "dependencies": ["elasticsearch-operator"],
+  "wave": "2"
+}

--- a/kubernetes/main/apps/database/elasticsearch/kustomization.yaml
+++ b/kubernetes/main/apps/database/elasticsearch/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: elastic-system
+resources:
+  - cluster.yaml


### PR DESCRIPTION
Add the Elastic Cloud on Kubernetes operator and a single-node Elasticsearch app so Argo CD can deploy a working cluster in the homelab.

💘 Generated with Crush

Assisted-by: GPT-5.4 via Crush <crush@charm.land>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced Elasticsearch Operator (ECK) to enable deployment and management of Elasticsearch clusters within Kubernetes
  * Added support for deploying single-node Elasticsearch clusters using the operator

* **Documentation**
  * Added documentation explaining the Elasticsearch Operator setup and configuration
  * Added documentation for Elasticsearch cluster deployment procedures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->