### PR TITLE
fix(elasticsearch): make ECK operator compatible with restricted pod security

### DIFF
--- a/kubernetes/main/apps/database/elasticsearch-operator/kustomization.yaml
+++ b/kubernetes/main/apps/database/elasticsearch-operator/kustomization.yaml
@@ -7,4 +7,5 @@ helmCharts:
     releaseName: elastic-operator
     repo: https://helm.elastic.co
     version: 3.3.2
+    valuesFile: values.yaml
     includeCRDs: true

--- a/kubernetes/main/apps/database/elasticsearch-operator/values.yaml
+++ b/kubernetes/main/apps/database/elasticsearch-operator/values.yaml
@@ -1,0 +1,14 @@
+---
+podSecurityContext:
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault


### PR DESCRIPTION
Set the ECK operator Helm values to apply RuntimeDefault seccomp profiles so the StatefulSet can be admitted on clusters enforcing the restricted PodSecurity policy.

💘 Generated with Crush

Assisted-by: GPT-5.4 via Crush <crush@charm.land>
