### PR TITLE
fix(argocd): enable server-side apply for bootstrap sync

### DIFF
--- a/kubernetes/main/bootstrap/argocd.yaml
+++ b/kubernetes/main/bootstrap/argocd.yaml
@@ -23,3 +23,4 @@ spec:
       allowEmpty: true
     syncOptions:
       - allowEmpty=true
+      - ServerSideApply=true


### PR DESCRIPTION
Enable server-side apply during the Argo CD bootstrap application sync so bootstrap updates can handle resources that need SSA semantics consistently.

💘 Generated with Crush

Assisted-by: GPT-5.4 via Crush <crush@charm.land>
