### PR TITLE
fix(elasticsearch): add seccompProfile to all ECK containers for PodSecurity compliance

### DIFF
--- a/kubernetes/main/apps/database/elasticsearch/cluster.yaml
+++ b/kubernetes/main/apps/database/elasticsearch/cluster.yaml
@@ -10,3 +10,21 @@ spec:
       count: 1
       config:
         node.store.allow_mmap: false
+      podTemplate:
+        spec:
+          securityContext:
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: elasticsearch
+              securityContext:
+                seccompProfile:
+                  type: RuntimeDefault
+            - name: elastic-internal-init-filesystem
+              securityContext:
+                seccompProfile:
+                  type: RuntimeDefault
+            - name: elastic-internal-suspend
+              securityContext:
+                seccompProfile:
+                  type: RuntimeDefault


### PR DESCRIPTION
💘 Generated with Crush

Assisted-by: Qwen 3.6-27B AWQ INT4 via Crush <crush@charm.land>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced Elasticsearch infrastructure security by implementing stricter pod-level security configurations. This change strengthens the default security policies applied to Elasticsearch pods, improving overall system hardening and compliance with container security best practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->