### PR TITLE
feat(spotizerr): configure Dragonfly Redis and 1Password admin credentials

### DIFF
--- a/kubernetes/main/apps/media/spotizerr/base/externalsecret.yaml
+++ b/kubernetes/main/apps/media/spotizerr/base/externalsecret.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: spotizerr-admin
+spec:
+  refreshInterval: 24h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: spotizerr-admin-secret
+    creationPolicy: Owner
+    template:
+      data:
+        username: "{{ .spotizerr_admin_username }}"
+        password: "{{ .spotizerr_admin_password }}"
+  dataFrom:
+    - extract:
+        key: spotizerr
+      rewrite:
+        - regexp:
+            source: "(.*)"
+            target: "spotizerr_$1"

--- a/kubernetes/main/apps/media/spotizerr/config.json
+++ b/kubernetes/main/apps/media/spotizerr/config.json
@@ -11,7 +11,8 @@
     "csi-driver-nfs",
     "prometheus-operator",
     "metallb",
-    "openebs"
+    "openebs",
+    "dragonfly"
   ],
-  "wave": "4"
+  "wave": "5"
 }

--- a/kubernetes/main/apps/media/spotizerr/kustomization.yaml
+++ b/kubernetes/main/apps/media/spotizerr/kustomization.yaml
@@ -16,6 +16,7 @@ helmCharts:
     namespace: spotizerr
     valuesFile: cloudflare-values.yaml
 resources:
+  - ./base/externalsecret.yaml
   - ./base/pvc/config/volsync-external-secret.yaml
   - ./base/pvc/config/volsync-replication-source.yaml
   - ./base/pvc/config/volsync-replication-destination.yaml

--- a/kubernetes/main/apps/media/spotizerr/values.yaml
+++ b/kubernetes/main/apps/media/spotizerr/values.yaml
@@ -38,6 +38,20 @@ controllers:
         env:
           PUID: "1001"
           PGID: "1001"
+          REDIS_HOST: dragonfly.database.svc.cluster.local
+          REDIS_PORT: "6379"
+          REDIS_DB: "0"
+          REDIS_PASSWORD: ""
+          DEFAULT_ADMIN_USERNAME:
+            valueFrom:
+              secretKeyRef:
+                name: spotizerr-admin-secret
+                key: username
+          DEFAULT_ADMIN_PASSWORD:
+            valueFrom:
+              secretKeyRef:
+                name: spotizerr-admin-secret
+                key: password
 service:
   spotizerr:
     controller: spotizerr


### PR DESCRIPTION
- Add REDIS_HOST, REDIS_PORT, REDIS_DB, REDIS_PASSWORD env vars pointing to Dragonfly
- Add DEFAULT_ADMIN_USERNAME and DEFAULT_ADMIN_PASSWORD from 1Password secret
- Create ExternalSecret to pull spotizerr credentials from 1Password
- Add dragonfly to app dependencies to ensure deployment order

🤖 Generated with Crush

Assisted-by: Claude Haiku 4.5 via Crush <crush@charm.land>
