### PR TITLE
fix(argocd): configure LoadBalancer service with external DNS

### DIFF
--- a/kubernetes/main/bootstrap/argocd/patches/argocd-server.yaml
+++ b/kubernetes/main/bootstrap/argocd/patches/argocd-server.yaml
@@ -4,4 +4,14 @@ kind: Service
 metadata:
   name: argocd-server
 spec:
-  type: ClusterIP
+  ports:
+    http:
+      port: 80
+  type: LoadBalancer
+  annotations:
+    external-dns.alpha.kubernetes.io/hostname: argocd.stoneydavis.local
+    external-dns.alpha.kubernetes.io/ttl: "1800"
+    external-dns.alpha.kubernetes.io/webhook-comment: "k8s_managed"
+    external-dns.alpha.kubernetes.io/webhook-match-subdomain: "true"
+    external-dns.alpha.kubernetes.io/webhook-disabled: "false"
+  externalTrafficPolicy: Cluster


### PR DESCRIPTION
- Change argocd-server service type from ClusterIP to LoadBalancer
- Add external-dns annotations for DNS hostname management
- Set externalTrafficPolicy to Cluster
- Configure service port mapping for HTTP access

🤖 Generated with Crush

Assisted-by: Claude Haiku 4.5 via Crush <crush@charm.land>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Argo CD server is now externally accessible through LoadBalancer configuration
  * Added HTTP port 80 mapping for standard web traffic access
  * Configured DNS hostname management (argocd.stoneydavis.local) with external DNS resolution
  * Updated external traffic policy for cluster-level resource handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->