### PR TITLE
fix(elasticsearch): remove redundant container seccompProfile entries

### DIFF
--- a/kubernetes/main/apps/database/elasticsearch/cluster.yaml
+++ b/kubernetes/main/apps/database/elasticsearch/cluster.yaml
@@ -15,16 +15,3 @@ spec:
           securityContext:
             seccompProfile:
               type: RuntimeDefault
-          containers:
-            - name: elasticsearch
-              securityContext:
-                seccompProfile:
-                  type: RuntimeDefault
-            - name: elastic-internal-init-filesystem
-              securityContext:
-                seccompProfile:
-                  type: RuntimeDefault
-            - name: elastic-internal-suspend
-              securityContext:
-                seccompProfile:
-                  type: RuntimeDefault


### PR DESCRIPTION
Container-level seccompProfile settings are inherited from pod spec, so individual container entries are redundant.

🤖 Generated with Crush

Assisted-by: Claude Haiku 4.5 via Crush <crush@charm.land>
