### PR TITLE
fix(postgres): grant SUPERUSER privilege to immich database user

### DIFF
--- a/kubernetes/main/apps/database/postgres/base/postgres-cluster.yaml
+++ b/kubernetes/main/apps/database/postgres/base/postgres-cluster.yaml
@@ -67,6 +67,7 @@ spec:
     - name: immich
       databases:
         - immich
+      options: "SUPERUSER"
       password:
         type: AlphaNumeric
   backups:


### PR DESCRIPTION
- Allow immich user to create pgvector extension
- Required for Immich to initialize its database on first startup
- Resolves 'permission denied to create extension vector' error
