### PR TITLE
feat(headscale): add OIDC configuration with AWS Secrets Manager integration

### DIFF
--- a/.github/workflows/ansible-scheduled.yaml
+++ b/.github/workflows/ansible-scheduled.yaml
@@ -22,7 +22,7 @@ jobs:
           version: latest
           args: --login-server=${{ vars.TAILSCALE_LOGIN_SERVER }} --accept-dns
           hostname: github-runner-${{ github.run_id }}
-          ping: "${{ vars.TAILSCALE_PING_HOST }}"
+          ping: "${{ vars.BASTION_HOST }}"
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v6
         with:

--- a/.github/workflows/ansible-scheduled.yaml
+++ b/.github/workflows/ansible-scheduled.yaml
@@ -22,7 +22,7 @@ jobs:
           version: latest
           args: --login-server=${{ vars.TAILSCALE_LOGIN_SERVER }} --accept-dns
           hostname: github-runner-${{ github.run_id }}
-          ping: "${{ vars.BASTION_HOST }}"
+          ping: "${{ vars.TAILSCALE_PING_HOST }}"
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v6
         with:

--- a/ansible/roles/headscale/tasks/main.yaml
+++ b/ansible/roles/headscale/tasks/main.yaml
@@ -44,8 +44,8 @@
     mode: '0755'
 - name: Add headscale config
   become: true
-  ansible.builtin.copy:
-    src: config.yaml
+  ansible.builtin.template:
+    src: config.yaml.j2
     dest: "/etc/headscale/config.yaml"
     owner: root
     group: root

--- a/ansible/roles/headscale/templates/config.yaml.j2
+++ b/ansible/roles/headscale/templates/config.yaml.j2
@@ -298,3 +298,7 @@ logtail:
 # default static port 41641. This option is intended as a workaround for some buggy
 # firewall devices. See https://tailscale.com/kb/1181/firewalls/ for more information.
 randomize_client_port: false
+oidc:
+  issuer: https://accounts.google.com
+  client_id: "{{ lookup('amazon.aws.aws_secret', 'weasel.stoneydavis.com/oidc/client-id', region=lookup('env', 'AWS_REGION')) }}"
+  client_secret: "{{ lookup('amazon.aws.aws_secret', 'weasel.stoneydavis.com/oidc/client-secret', region=lookup('env', 'AWS_REGION')) }}"


### PR DESCRIPTION
- Configure Google OIDC authentication for Headscale
- Move config.yaml to templates directory to enable Jinja2 variable expansion
- Use AWS Secrets Manager lookups for client_id and client_secret

🤖 Generated with Crush

Assisted-by: Claude Haiku 4.5 via Crush <crush@charm.land>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OIDC (OpenID Connect) authentication configuration support, enabling federated identity integration
  * Configuration now retrieves client credentials securely from AWS Secrets Manager with environment-based region selection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->