### PR TITLE
fix(k3s): only apply argocd kustomize if deployment doesn't exist

### DIFF
--- a/ansible/roles/k3s_controlplane/tasks/argocd.yml
+++ b/ansible/roles/k3s_controlplane/tasks/argocd.yml
@@ -20,8 +20,14 @@
           pod-security.kubernetes.io/audit: baseline
           pod-security.kubernetes.io/enforce: baseline
           pod-security.kubernetes.io/warn: baseline
-# Apply argoCD deployment manifest same as what ArgoCD itself is manged with, this eliminates changes during Ansible deploys.
-- name: ArgoCD | Apply Kustomize # this is not the right way to do it but using kubernetes.core.k8s was failing for some reason.
+- name: ArgoCD | Check if argocd-server deployment exists
+  kubernetes.core.k8s_info:
+    kubeconfig: /etc/rancher/k3s/k3s.yaml
+    kind: Deployment
+    name: argocd-server
+    namespace: argocd
+  register: k3s_controlplane_argocd_server_deployment
+- name: ArgoCD | Apply Kustomize
   ansible.builtin.shell:
     cmd: >-
       set -o pipefail &&
@@ -29,6 +35,7 @@
       --enable-helm=True {{ k3s_git_repo }}/kubernetes/{{ git_sub_path }}/bootstrap/argocd
       | k3s kubectl apply --server-side=true -f -
     executable: /bin/bash
+  when: k3s_controlplane_argocd_server_deployment.resources | length == 0
   changed_when: true
 - name: ArgoCD | Wait for ArgoCD to be ready
   become: false


### PR DESCRIPTION
Add a check task that verifies the argocd-server deployment exists before
applying the kustomize manifests. This prevents unnecessary reconciliation
on subsequent runs and allows Argo CD to be the source of truth after
initial deployment.

Changes:
- Add new task to check for argocd-server deployment in argocd namespace
- Conditionally execute kustomize apply only if deployment is absent
- Removes duplicate deployment on idempotent runs

🐘 Generated with Crush

Assisted-by: Claude Haiku 4.5 via Crush <crush@charm.land>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced ArgoCD deployment process with conditional application checks for improved reliability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/raypappa/homelab/pull/1275)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->