### PR TITLE
fix(immich): restore direct postgres connection and fix pgbouncer SUPERUSER option ordering

### DIFF
--- a/kubernetes/main/apps/database/postgres/base/postgres-cluster.yaml
+++ b/kubernetes/main/apps/database/postgres/base/postgres-cluster.yaml
@@ -65,9 +65,9 @@ spec:
       password:
         type: AlphaNumeric
     - name: immich
+      options: "SUPERUSER"
       databases:
         - immich
-      options: "SUPERUSER"
       password:
         type: AlphaNumeric
   backups:

--- a/kubernetes/main/apps/selfhosted/immich/base/external-secret.yaml
+++ b/kubernetes/main/apps/selfhosted/immich/base/external-secret.yaml
@@ -31,8 +31,10 @@ spec:
     template:
       type: Opaque
       data:
-        DB_HOSTNAME: '{{ index . "pgbouncer-host" }}'
-        DB_PORT: '{{ index . "pgbouncer-port" }}'
+        DB_HOSTNAME: '{{ index . "host" }}'
+        DB_PORT: '{{ index . "port" }}'
+        # DB_HOSTNAME: '{{ index . "pgbouncer-host" }}'
+        # DB_PORT: '{{ index . "pgbouncer-port" }}'
         DB_DATABASE_NAME: '{{ index . "dbname" }}'
         DB_USERNAME: '{{ index . "user" }}'
         DB_PASSWORD: '{{ index . "password" }}'


### PR DESCRIPTION
- Revert immich external-secret to use direct postgres connection (host/port) instead of pgbouncer
- Move SUPERUSER option before databases array in postgres-cluster for correct CloudNativePG schema
- Immich requires direct postgres access for certain operations

🐘 Generated with Crush

Assisted-by: Claude Haiku 4.5 via Crush <crush@charm.land>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chore**
  * Reorganized PostgreSQL cluster user configuration entries

* **Refactor**
  * Updated database service connection configuration to source hostname and port from direct fields rather than proxy-based configuration; previous configuration retained as reference

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/raypappa/homelab/pull/1277)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->