### PR TITLE
refactor(postgres): disable joplin and immich users from pgcluster definition

### DIFF
--- a/kubernetes/main/apps/database/postgres/base/postgres-cluster.yaml
+++ b/kubernetes/main/apps/database/postgres/base/postgres-cluster.yaml
@@ -58,18 +58,13 @@ spec:
       options: "SUPERUSER"
       password:
         type: AlphaNumeric
-    # Applications
-    - name: joplin
-      databases:
-        - joplin
-      password:
-        type: AlphaNumeric
-    - name: immich
-      options: "SUPERUSER"
-      databases:
-        - immich
-      password:
-        type: AlphaNumeric
+        # Applications
+        # - name: immich
+        #   options: "SUPERUSER"
+        #   databases:
+        #     - immich
+        #   password:
+        #     type: AlphaNumeric
   backups:
     pgbackrest:
       configuration: &backupConfig


### PR DESCRIPTION
Remove application-specific users from the pgcluster manifest as these should be managed through Argo CD app configurations rather than centralized in the postgres base definition. This enables better app lifecycle independence and cleaner separation of concerns.

🤖 Generated with Crush

Assisted-by: Claude Haiku 4.5 via Crush <crush@charm.land>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified database cluster user configuration by removing inactive application user entries and adding commented-out placeholder sections to streamline future application setup and maintenance.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/raypappa/homelab/pull/1278)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->