### PR TITLE
feat: enable auto-merge for GitHub Actions updates in Renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -42,6 +42,14 @@
       '/(^|/)kubernetes/.+\\.ya?ml(?:\\.j2)?$/',
     ],
   },
+  packageRules: [
+    {
+      matchManagers: ['github-actions'],
+      automerge: true,
+      automergeType: 'pr',
+      automergeStrategy: 'squash',
+    },
+  ],
   postUpdateOptions: [
     'pnpmDedupe',
   ],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Renovate configuration to manage dependency updates.
  * Enabled automated pull request merging for GitHub Actions updates using a squash strategy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->