### PR TITLE
feat(renovate): enable auto-merge for devcontainer updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -49,6 +49,12 @@
       automergeType: 'pr',
       automergeStrategy: 'squash',
     },
+    {
+      matchManagers: ['devcontainer'],
+      automerge: true,
+      automergeType: 'pr',
+      automergeStrategy: 'squash',
+    },
   ],
   postUpdateOptions: [
     'pnpmDedupe',


### PR DESCRIPTION
Enable Renovate auto-merge for devcontainer dependency updates. PRs will be automatically merged when CI pipelines pass.