### PR TITLE
feat(k3s_agent): add node taint support via kubernetes.core.k8s_taint

### DIFF
--- a/ansible/roles/k3s_agent/defaults/main.yml
+++ b/ansible/roles/k3s_agent/defaults/main.yml
@@ -1,2 +1,3 @@
 ---
 k3s_agent_server_location: /var/lib/rancher/k3s
+k3s_agent_node_taints: []

--- a/ansible/roles/k3s_agent/tasks/main.yml
+++ b/ansible/roles/k3s_agent/tasks/main.yml
@@ -40,3 +40,6 @@
     name: k3s
     state: restarted
   when: k3s_agent_copied_k3s_config.changed and k3s_agent_k3s_service.changed
+- name: Configure node taints
+  ansible.builtin.include_tasks:
+    file: taints.yml

--- a/ansible/roles/k3s_agent/tasks/taints.yml
+++ b/ansible/roles/k3s_agent/tasks/taints.yml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/ansible.json#/$defs/tasks
+- name: k3s_agent | Apply node taints via Kubernetes API
+  kubernetes.core.k8s_taint:
+    state: present
+    name: "{{ inventory_hostname }}"
+    taints: "{{ k3s_agent_node_taints }}"
+  delegate_to: "{{ k3s_controlplane_singleton_host }}"
+  when: k3s_agent_node_taints is defined and k3s_agent_node_taints | length > 0


### PR DESCRIPTION
Add support for configuring node taints from host/group vars.
Taints are applied delegated to the k3s control plane after agent setup.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring Kubernetes node taints for K3s agent nodes.
  * Node taints are now applied automatically during agent setup when taints are provided.
  * Introduced a default empty taints configuration to preserve existing behavior when no taints are configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->