### PR TITLE
fix(radarr): switch tailscale sidecar to userspace mode for PodSecurity restricted compliance

### DIFF
--- a/kubernetes/main/apps/downloads/radarr/values.yaml
+++ b/kubernetes/main/apps/downloads/radarr/values.yaml
@@ -53,10 +53,14 @@ controllers:
                 name: tailscale-auth
                 key: TS_AUTHKEY
           TS_EXTRA_ARGS: "--login-server=https://weasel.stoneydavis.com --hostname=radarr"
-          TS_USERSPACE: "false"
+          TS_USERSPACE: "true"
           TS_STATE_DIR: "/var/lib/tailscale"
         securityContext:
-          privileged: true
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          readOnlyRootFilesystem: true
 service:
   main:
     controller: main


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Hardened the Radarr Tailscale sidecar by disabling privilege escalation.
  - Removed Linux capabilities and privileged access.
  - Enabled a read-only root filesystem.
  - Switched Tailscale to userspace networking mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->