### PR TITLE
fix(radarr): enable automountServiceAccountToken for tailscale sidecar

### DIFF
--- a/kubernetes/main/apps/downloads/radarr/values.yaml
+++ b/kubernetes/main/apps/downloads/radarr/values.yaml
@@ -1,6 +1,7 @@
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/refs/heads/main/charts/other/app-template/values.schema.json
 defaultPodOptions:
+  automountServiceAccountToken: true
   securityContext:
     runAsUser: 1001
     runAsGroup: 1001


### PR DESCRIPTION
The tailscale sidecar needs the SA token to read the namespace file.
The app-template defaults automountServiceAccountToken to false.
