### PR TITLE
fix(radarr): move tailscale state/socket under /tmp to fix restricted PSA

### DIFF
--- a/.cspell-dictionaries/linux.txt
+++ b/.cspell-dictionaries/linux.txt
@@ -82,3 +82,6 @@ zpath
 hmackey
 cronie
 epel
+DAC_OVERRIDE
+FOWNER
+tailscaled

--- a/kubernetes/main/apps/downloads/radarr/values.yaml
+++ b/kubernetes/main/apps/downloads/radarr/values.yaml
@@ -55,12 +55,14 @@ controllers:
           TS_EXTRA_ARGS: "--login-server=https://weasel.stoneydavis.com --hostname=radarr"
           TS_KUBE_SECRET: ""
           TS_USERSPACE: "true"
-          TS_STATE_DIR: "/var/lib/tailscale"
+          TS_STATE_DIR: "/tmp/tailscale/state"
+          TS_SOCKET: "/tmp/tailscale/run/tailscaled.sock"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
             drop:
               - ALL
+          readOnlyRootFilesystem: false
 service:
   main:
     controller: main
@@ -93,6 +95,4 @@ persistence:
     advancedMounts:
       main:
         tailscale:
-          - path: /var/lib/tailscale
-          - path: /var/run/tailscale
           - path: /tmp


### PR DESCRIPTION
Mount emptyDir at /tmp instead of /var/lib/tailscale and /var/run/tailscale.
Tailscale creates its own subdirectories under /tmp, so it owns them as
UID 1001 without needing DAC_OVERRIDE or FOWNER capabilities.

- TS_STATE_DIR=/tmp/tailscale/state
- TS_SOCKET=/tmp/tailscale/run/tailscaled.sock
- Removed readOnlyRootFilesystem from tailscale container
