### PR TITLE
fix(headscale): add split DNS for stoneydavis.local

### DIFF
--- a/ansible/roles/headscale/templates/config.yaml.j2
+++ b/ansible/roles/headscale/templates/config.yaml.j2
@@ -297,12 +297,9 @@ dns:
 
     # Split DNS (see https://tailscale.com/kb/1054/dns/),
     # a map of domains and which DNS server to use for each.
-    split: {}
-      # foo.bar.com:
-      #   - 1.1.1.1
-      # darp.headscale.net:
-      #   - 1.1.1.1
-      #   - 8.8.8.8
+    split:
+      stoneydavis.local:
+        - 10.49.48.1
 
   # Set custom DNS search domains. With MagicDNS enabled,
   # your tailnet base_domain is always the first search domain.


### PR DESCRIPTION
Route .stoneydavis.local queries to MikroTik router (10.49.48.1)
instead of Cloudflare when clients are on the tailnet.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated DNS resolution for the `stoneydavis.local` domain to use the designated DNS server.
  * Improved split-DNS configuration for more reliable access to local domain resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->