### PR TITLE
fix/radarr tmp volume

### DIFF
--- a/ansible/host_vars/panda.stoneydavis.local
+++ b/ansible/host_vars/panda.stoneydavis.local
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ansible/ansible-lint/refs/heads/main/src/ansiblelint/schemas/vars.json
+# vim: ft=yaml
+k3s_agent_node_taints:
+  - key: dedicated
+    value: gpu
+    effect: NoExecute

--- a/ansible/hosts
+++ b/ansible/hosts
@@ -6,6 +6,9 @@ prod_k8s_controlplane:
     kubernetes-node-0002.stoneydavis.local:
     kubernetes-node-0003.stoneydavis.local:
     kubernetes-node-0004.stoneydavis.local:
+prod_k8s_agents:
+  hosts:
+    panda.stoneydavis.local:
 prod_k8s_cluster:
   children:
     prod_k8s_controlplane:

--- a/kubernetes/main/apps/downloads/radarr/values.yaml
+++ b/kubernetes/main/apps/downloads/radarr/values.yaml
@@ -90,9 +90,18 @@ persistence:
     enabled: true
     type: persistentVolumeClaim
     existingClaim: radarr-library-nfs
+  tmp:
+    enabled: true
+    type: emptyDir
+    sizeLimit: 128Mi
+    advancedMounts:
+      main:
+        main:
+          - path: /tmp
   tailscale-state:
     enabled: true
     type: emptyDir
+    sizeLimit: 128Mi
     advancedMounts:
       main:
         tailscale:


### PR DESCRIPTION
- **fix(radarr): add writable /tmp emptyDir for read-only root filesystem**
- **feat(ansible): add dedicated=gpu:NoExecute taint for panda**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for dedicating the Panda node to GPU workloads in the production Kubernetes cluster.
  * Added temporary storage for Radarr at `/tmp`.
  * Added a size limit for Radarr’s Tailscale state storage.

* **Infrastructure**
  * Updated production cluster inventory to include the Panda node as a Kubernetes agent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->