### PR TITLE
fix(ansible): remove dual network manager conflict on K3s nodes

### DIFF
--- a/ansible/roles/_k3s_prereq/files/dhcp_all_network_interfaces
+++ b/ansible/roles/_k3s_prereq/files/dhcp_all_network_interfaces
@@ -2,12 +2,6 @@
 # This file describes the network interfaces available on your system
 # and how to activate them. For more information, see interfaces(5).
 
-source /etc/network/interfaces.d/*
-
 # The loopback network interface
 auto lo
 iface lo inet loopback
-auto /en*=en
-iface en inet dhcp
-auto /eth*=eth
-iface eth inet dhcp

--- a/ansible/roles/common_critical/tasks/main.yaml
+++ b/ansible/roles/common_critical/tasks/main.yaml
@@ -34,6 +34,14 @@
     state: reloaded
   # running this on ovh hosts causes them to break.
   when: hostvars[inventory_hostname]['ansible_default_ipv4']['address'] is ansible.utils.private
+- name: Mask networking.service
+  become: true
+  register: common_critical_networking
+  ansible.builtin.systemd_service:
+    name: networking.service
+    masked: true
+    state: stopped
+  when: hostvars[inventory_hostname]['ansible_default_ipv4']['address'] is ansible.utils.private
 - name: Remove legacy apt sources.list
   become: true
   ansible.builtin.file:
@@ -137,5 +145,6 @@
   become: true
   throttle: 1
   when: common_critical_packages.changed or common_critical_dhclient.changed or common_critical_networkd.changed
+    or common_critical_networking.changed
   ansible.builtin.reboot:
     reboot_timeout: 600


### PR DESCRIPTION
Strip /etc/network/interfaces to loopback-only since systemd-networkd
already handles DHCP via dhcp.network. Mask networking.service to
prevent ifupdown2 from competing for the same interfaces.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved network configuration stability on hosts using private IPv4 addresses.
  * Disabled conflicting legacy networking services to prevent unintended interface configuration.
  * Hosts now reboot automatically when critical networking settings change, ensuring changes take effect.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->