### PR TITLE
fix(rook-ceph): align pool default size and enable auto OSD removal

### DIFF
--- a/kubernetes/main/apps/storage/rook-ceph-cluster/rook-ceph-cluster-values.yaml
+++ b/kubernetes/main/apps/storage/rook-ceph-cluster/rook-ceph-cluster-values.yaml
@@ -30,12 +30,13 @@ cephClusterSpec:
     disable: true
   cephConfig:
     global:
-      osd_pool_default_size: "3"
+      osd_pool_default_size: "2"
       # bdev_flock_retry: "20"
       # bluefs_buffered_io: "false"
       # mon_data_avail_warn: "10"
   disruptionManagement:
     managePodBudgets: false
+  removeOSDsIfOutAndSafeToRemove: true
 cephFileSystemVolumeSnapshotClass:
   enabled: true
 cephBlockPoolsVolumeSnapshotClass:


### PR DESCRIPTION
- Change osd_pool_default_size from 3 to 2 to match actual pool config
- Enable removeOSDsIfOutAndSafeToRemove for operator auto-cleanup


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration**
  - Reduced the default Ceph storage replication level from three copies to two.
  - Enabled automatic removal of storage devices when they are offline and safe to remove.
  - Preserved the existing pod disruption budget management setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->