### PR TITLE
feat/k3s health script

### DIFF
--- a/.cspell-dictionaries/k8s.txt
+++ b/.cspell-dictionaries/k8s.txt
@@ -135,3 +135,5 @@ dbfilename
 drummyfloyd
 mirceanton
 kubesec
+Schedulable
+schedulable

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -71,3 +71,13 @@ tasks:
     requires:
       vars:
         - dir
+  health:check:
+    desc: "Run Kubernetes and Argo CD health checks"
+    silent: true
+    cmds:
+      - uv run python scripts/health_check.py {{.CLI_ARGS}}
+  health:check:json:
+    desc: "Run Kubernetes and Argo CD health checks (JSON output)"
+    silent: true
+    cmds:
+      - uv run python scripts/health_check.py --json {{.CLI_ARGS}}

--- a/ansible/galaxy.yaml
+++ b/ansible/galaxy.yaml
@@ -31,7 +31,7 @@ collections:
     version: "4.5.2"
   - name: artis3n.tailscale
     # renovate: datasource=galaxy-collection packageName=artis3n.tailscale
-    version: "1.0.1"
+    version: "1.2.1"
   - name: community.crypto
     # renovate: datasource=galaxy-collection packageName=community.crypto
     version: "3.0.4"
@@ -43,4 +43,4 @@ collections:
     type: git
   - name: ansible.posix
     # renovate: datasource=galaxy-collection packageName=ansible.posix
-    version: 2.0.0
+    version: "2.1.0"

--- a/ansible/homelab.yaml
+++ b/ansible/homelab.yaml
@@ -5,6 +5,8 @@
 - name: Headscale
   hosts: headscale
   become: true
+  tags:
+    - headscale
   roles:
     - common_critical
     - common
@@ -12,6 +14,8 @@
     - headscale
 - name: Common
   hosts: all
+  tags:
+    - common
   roles:
     # It's just one package... it's just that it'll break DNS resolution until
     # things get restarted, and a reboot is the easy way to do this. If DNS
@@ -30,12 +34,16 @@
     - k3s_controlplane
 - name: Production Kubernetes Agents
   order: sorted
+  tags:
+    - prod_k8s_agent
   hosts:
     - prod_k8s_agent
   roles:
     - k3s_agent
 - name: Game Server
   hosts:
+    - game_server
+  tags:
     - game_server
   roles:
     - game-server
@@ -50,10 +58,14 @@
 - name: NFS Server
   hosts:
     - nfs_server
+  tags:
+    - nfs_server
   roles:
     - nfs_server
 - name: TURN/STUN server
   hosts:
+    - turn_stun
+  tags:
     - turn_stun
   roles:
     - role: certbot

--- a/ansible/hosts
+++ b/ansible/hosts
@@ -6,13 +6,13 @@ prod_k8s_controlplane:
     kubernetes-node-0002.stoneydavis.local:
     kubernetes-node-0003.stoneydavis.local:
     kubernetes-node-0004.stoneydavis.local:
-prod_k8s_agents:
+prod_k8s_agent:
   hosts:
     panda.stoneydavis.local:
 prod_k8s_cluster:
   children:
     prod_k8s_controlplane:
-    prod_k8s_agents:
+    prod_k8s_agent:
 game_server:
   hosts:
     panda.stoneydavis.local:

--- a/ansible/roles/_k3s_prereq/tasks/main.yml
+++ b/ansible/roles/_k3s_prereq/tasks/main.yml
@@ -26,7 +26,7 @@
     value: "1"
     state: present
     reload: true
-  when: ansible_all_ipv6_addresses | length > 0
+  when: ansible_facts.all_ipv6_addresses | length > 0
 
 # https://github.com/quic-go/quic-go/wiki/UDP-Buffer-Sizes
 - name: Enable set wmem for QUIC
@@ -51,7 +51,7 @@
     dest: /usr/local/bin/k3s
     owner: root
     group: root
-    mode: '0755'
+    mode: "0755"
   when: ansible_facts.architecture == "x86_64"
 
 - name: Create kubectl symlink
@@ -70,37 +70,37 @@
   ansible.builtin.file:
     path: /etc/rancher/k3s/
     state: directory
-    mode: '0700'
+    mode: "0700"
 
 - name: Create /var/lib/rancher/k3s/server/logs directory
   ansible.builtin.file:
     path: /var/lib/rancher/k3s/server/logs
     state: directory
-    mode: '0700'
+    mode: "0700"
 
 - name: Create /var/lib/rancher/k3s/server/manifests directory
   ansible.builtin.file:
     path: /var/lib/rancher/k3s/server/manifests
     state: directory
-    mode: '0700'
+    mode: "0700"
 
 - name: Create /var/lib/rancher/k3s/agent/etc/ directory
   ansible.builtin.file:
     path: /var/lib/rancher/k3s/agent/etc
     state: directory
-    mode: '0755'
+    mode: "0755"
 
 - name: Create /var/lib/rancher/k3s/server/ directory
   ansible.builtin.file:
     path: /var/lib/rancher/k3s/server
     state: directory
-    mode: '0700'
+    mode: "0700"
 
 - name: Create /var/lib/rancher/k3s/agent/etc/kubelet.conf.d restricted directory
   ansible.builtin.file:
     path: /var/lib/rancher/k3s/agent/etc/kubelet.conf.d
     state: directory
-    mode: '0700'
+    mode: "0700"
 
 - name: Install kubelet config file for graceful shutdown
   ansible.builtin.copy:
@@ -108,7 +108,7 @@
     dest: /var/lib/rancher/k3s/agent/etc/kubelet.conf.d/10-k3s-graceful-shutdown.conf
     owner: root
     group: root
-    mode: '0600'
+    mode: "0600"
 
 - name: Ensure interfaces DHCP
   ansible.builtin.copy:
@@ -116,7 +116,7 @@
     dest: /etc/network/interfaces
     owner: root
     group: root
-    mode: '0644'
+    mode: "0644"
 - name: Ensure required packages are installed
   become: true
   ansible.builtin.apt:
@@ -169,4 +169,4 @@
     dest: /var/lib/rancher/k3s/agent/etc/kubelet.conf.d/20-k3s-protect-kernel-defaults.conf
     owner: root
     group: root
-    mode: '0600'
+    mode: "0600"

--- a/ansible/roles/common_critical/files/dhcp.network
+++ b/ansible/roles/common_critical/files/dhcp.network
@@ -2,7 +2,9 @@
 Name=en*
 
 [Network]
-DHCP=yes
+DHCP=ipv4
+IPv6AcceptRA=false
+KeepConfiguration=yes
 
 [DHCPv4]
 UseDomains=true

--- a/ansible/roles/common_critical/tasks/main.yaml
+++ b/ansible/roles/common_critical/tasks/main.yaml
@@ -96,6 +96,18 @@
         uris: http://security.debian.org/debian-security/
         suites: trixie-security
 
+- name: Stat tailscale.sources
+  become: true
+  ansible.builtin.stat:
+    path: /etc/apt/sources.list.d/tailscale.sources
+  register: tailscale_sources
+  when: ansible_facts['os_family'] == "Debian"
+- name: Remove legacy tailscale.list if tailscale.sources exists
+  become: true
+  ansible.builtin.file:
+    path: /etc/apt/sources.list.d/tailscale.list
+    state: absent
+  when: ansible_facts['os_family'] == "Debian" and tailscale_sources.stat.exists
 - name: Upgrade the OS (apt-get dist-upgrade)
   become: true
   ansible.builtin.apt:

--- a/ansible/roles/common_critical/tasks/main.yaml
+++ b/ansible/roles/common_critical/tasks/main.yaml
@@ -15,7 +15,8 @@
     mode: "0644"
     owner: root
     group: root
-  when: hostvars[inventory_hostname]['ansible_default_ipv4']['address'] is ansible.utils.private
+  when: hostvars[inventory_hostname]['ansible_facts']['default_ipv4']['address'] is
+    ansible.utils.private
 - name: Apply dhcp.network to enable using dns from dhcp
   become: true
   register: common_critical_networkd
@@ -25,7 +26,8 @@
     mode: "0644"
     owner: root
     group: root
-  when: hostvars[inventory_hostname]['ansible_default_ipv4']['address'] is ansible.utils.private
+  when: hostvars[inventory_hostname]['ansible_facts']['default_ipv4']['address'] is
+    ansible.utils.private
 - name: Enable networkd
   become: true
   ansible.builtin.systemd_service:
@@ -33,7 +35,8 @@
     name: systemd-networkd
     state: reloaded
   # running this on ovh hosts causes them to break.
-  when: hostvars[inventory_hostname]['ansible_default_ipv4']['address'] is ansible.utils.private
+  when: hostvars[inventory_hostname]['ansible_facts']['default_ipv4']['address'] is
+    ansible.utils.private
 - name: Mask networking.service
   become: true
   register: common_critical_networking
@@ -41,7 +44,8 @@
     name: networking.service
     masked: true
     state: stopped
-  when: hostvars[inventory_hostname]['ansible_default_ipv4']['address'] is ansible.utils.private
+  when: hostvars[inventory_hostname]['ansible_facts']['default_ipv4']['address'] is
+    ansible.utils.private
 - name: Remove legacy apt sources.list
   become: true
   ansible.builtin.file:
@@ -126,7 +130,7 @@
     path: /etc/dhcp/dhclient-enter-hooks.d
     owner: root
     group: root
-    mode: '0755'
+    mode: "0755"
 - name: Remove dhclient's ability to overwrite systemd-resolved's /etc/resolv.conf
   become: true
   register: common_critical_dhclient

--- a/ansible/roles/k3s_controlplane/templates/k3s.service.j2
+++ b/ansible/roles/k3s_controlplane/templates/k3s.service.j2
@@ -7,7 +7,7 @@ After=network-online.target
 Type=notify
 ExecStartPre=-/sbin/modprobe br_netfilter
 ExecStartPre=-/sbin/modprobe overlay
-ExecStart=/usr/local/bin/k3s server --data-dir {{ k3s_server_location }} --kubelet-arg=config=/etc/rancher/k3s/kubelet.config --node-external-ip {{ ansible_default_ipv4['address'] }} --bind-address 0.0.0.0
+ExecStart=/usr/local/bin/k3s server --data-dir {{ k3s_server_location }} --kubelet-arg=config=/etc/rancher/k3s/kubelet.config --node-external-ip {{ ansible_facts['default_ipv4']['address'] }} --bind-address 0.0.0.0
 KillMode=process
 Delegate=yes
 # Having non-zero Limit*s causes performance problems due to accounting

--- a/scripts/health_check.py
+++ b/scripts/health_check.py
@@ -1,0 +1,470 @@
+#!/usr/bin/env python3
+"""Health checks for Kubernetes cluster and Argo CD applications.
+
+Reads cluster state via the Kubernetes API and reports on:
+  - Node health (Ready, Schedulable)
+  - System pod health (kube-system namespace)
+  - Argo CD application sync/health status (via Application CRD)
+  - Per-application pod readiness across managed namespaces
+
+Exit codes:
+  0 — all checks passed
+  1 — one or more checks failed
+  2 — connection or configuration error
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import sys
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, TYPE_CHECKING
+
+from kubernetes import client, config
+from kubernetes.client.rest import ApiException
+
+if TYPE_CHECKING:
+    from kubernetes.client.models.v1_node import V1Node
+    from kubernetes.client.models.v1_pod import V1Pod
+    from kubernetes.client.models.v1_node_condition import V1NodeCondition
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+ARGOCD_NAMESPACE = "argocd"
+SYSTEM_NAMESPACE = "kube-system"
+APPS_DIR = pathlib.Path("kubernetes/main/apps")
+
+# Colors (disabled when output is not a TTY)
+_USE_COLOR = sys.stdout.isatty()
+
+
+class _C:
+    """ANSI color codes."""
+
+    RED = "\033[91m" if _USE_COLOR else ""
+    GREEN = "\033[92m" if _USE_COLOR else ""
+    YELLOW = "\033[93m" if _USE_COLOR else ""
+    CYAN = "\033[96m" if _USE_COLOR else ""
+    BOLD = "\033[1m" if _USE_COLOR else ""
+    DIM = "\033[2m" if _USE_COLOR else ""
+    RESET = "\033[0m" if _USE_COLOR else ""
+
+
+# ---------------------------------------------------------------------------
+# Data types
+# ---------------------------------------------------------------------------
+
+
+class Status(Enum):
+    OK = "ok"
+    WARN = "warn"
+    FAIL = "fail"
+    SKIP = "skip"
+
+
+@dataclass
+class CheckResult:
+    name: str
+    status: Status
+    details: list[str] = field(default_factory=list)
+
+
+@dataclass
+class Report:
+    cluster_name: str
+    results: list[CheckResult] = field(default_factory=list)
+
+    @property
+    def overall(self) -> Status:
+        statuses = [r.status for r in self.results]
+        if Status.FAIL in statuses:
+            return Status.FAIL
+        if Status.WARN in statuses:
+            return Status.WARN
+        if all(s == Status.SKIP for s in statuses):
+            return Status.SKIP
+        return Status.OK
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _status_icon(s: Status) -> str:
+    return {
+        Status.OK: f"{_C.GREEN}●{_C.RESET}",
+        Status.WARN: f"{_C.YELLOW}●{_C.RESET}",
+        Status.FAIL: f"{_C.RED}●{_C.RESET}",
+        Status.SKIP: f"{_C.DIM}○{_C.RESET}",
+    }[s]
+
+
+def _load_config_files() -> dict[str, dict[str, Any]]:
+    """Load all active config.json files from kubernetes/main/apps/."""
+    apps: dict[str, dict[str, Any]] = {}
+    if not APPS_DIR.exists():
+        return apps
+    for config_path in APPS_DIR.rglob("config.json"):
+        try:
+            data: dict[str, Any] = json.loads(config_path.read_text())
+            apps[data["appName"]] = data
+        except (json.JSONDecodeError, KeyError):
+            continue
+    return apps
+
+
+# ---------------------------------------------------------------------------
+# Check functions
+# ---------------------------------------------------------------------------
+
+
+def check_nodes(v1: client.CoreV1Api) -> CheckResult:
+    """Check that all nodes are Ready and Schedulable."""
+    result = CheckResult(name="Cluster Nodes", status=Status.OK)
+    try:
+        nodes: list[V1Node] = v1.list_node().items
+    except ApiException as exc:
+        result.status = Status.FAIL
+        result.details.append(f"API error: {exc.reason}")
+        return result
+
+    if not nodes:
+        result.status = Status.WARN
+        result.details.append("No nodes found in cluster")
+        return result
+
+    for node in nodes:
+        meta = node.metadata
+        status_obj = node.status
+        spec_obj = node.spec
+        name = meta.name if meta else "<unknown>"
+        conditions: list[V1NodeCondition] = (
+            status_obj.conditions if status_obj and status_obj.conditions else []
+        )
+        ready_cond = next((c for c in conditions if c.type == "Ready"), None)
+        schedulable = not (spec_obj and spec_obj.unschedulable is True)
+
+        if ready_cond and ready_cond.status == "True":
+            if not schedulable:
+                result.status = Status.WARN
+                result.details.append(f"{name}: Ready but Unschedulable")
+        else:
+            result.status = Status.FAIL
+            ready_val = ready_cond.status if ready_cond else "Unknown"
+            result.details.append(f"{name}: NotReady (condition={ready_val})")
+
+    if not result.details:
+        result.details.append(f"{len(nodes)} node(s) healthy")
+    return result
+
+
+def check_system_pods(v1: client.CoreV1Api) -> CheckResult:
+    """Check that kube-system pods are running and ready."""
+    result = CheckResult(name="System Pods", status=Status.OK)
+    try:
+        pods: list[V1Pod] = v1.list_namespaced_pod(
+            namespace=SYSTEM_NAMESPACE,
+            field_selector="status.phase!=Running,status.phase!=Succeeded",
+        ).items
+    except ApiException as exc:
+        result.status = Status.FAIL
+        result.details.append(f"API error: {exc.reason}")
+        return result
+
+    if pods:
+        result.status = Status.FAIL
+        for pod in pods:
+            phase = pod.status.phase if pod.status else "Unknown"
+            pod_name = pod.metadata.name if pod.metadata else "<unknown>"
+            result.details.append(f"{pod_name}: {phase}")
+    else:
+        result.details.append(f"All pods running in {SYSTEM_NAMESPACE}")
+    return result
+
+
+def check_argo_apps(
+    custom_api: client.CustomObjectsApi,
+    config_apps: dict[str, dict[str, Any]],
+) -> CheckResult:
+    """Check Argo CD Application sync and health status."""
+    result = CheckResult(name="Argo CD Apps", status=Status.OK)
+
+    try:
+        apps_resource = custom_api.list_namespaced_custom_object(
+            group="argoproj.io",
+            version="v1alpha1",
+            namespace=ARGOCD_NAMESPACE,
+            plural="applications",
+        )
+    except ApiException as exc:
+        result.status = Status.FAIL
+        result.details.append(f"API error: {exc.reason}")
+        return result
+
+    items = apps_resource.get("items", [])
+    if not items:
+        result.status = Status.WARN
+        result.details.append("No Argo CD applications found")
+        return result
+
+    # Sort apps by wave, then by name within each wave
+    def _wave_sort_key(app: dict[str, Any]) -> tuple[int, str]:
+        name = app.get("metadata", {}).get("name", "")
+        wave_str = config_apps.get(name, {}).get("wave", "99")
+        try:
+            wave_num = int(wave_str)
+        except (ValueError, TypeError):
+            wave_num = 99
+        return (wave_num, name)
+
+    items = sorted(items, key=_wave_sort_key)
+
+    # Skip self-managing argocd apps
+    managed_items = [
+        a
+        for a in items
+        if a.get("metadata", {}).get("name", "") not in ("appset", "argocd")
+    ]
+
+    for app in managed_items:
+        name = app.get("metadata", {}).get("name", "<unknown>")
+        status = app.get("status", {})
+        sync_status = status.get("sync", {}).get("status", "Unknown")
+        health_status = status.get("health", {}).get("status", "Unknown")
+
+        is_unhealthy = health_status not in ("Healthy", "Missing")
+        is_out_of_sync = sync_status != "Synced"
+
+        if is_unhealthy or is_out_of_sync:
+            result.status = Status.FAIL
+            parts = [f"sync={sync_status}", f"health={health_status}"]
+            wave = config_apps.get(name, {}).get("wave", "?")
+            result.details.append(f"{name} [wave {wave}]: {', '.join(parts)}")
+
+    if not result.details:
+        result.details.append(f"{len(managed_items)} app(s) synced and healthy")
+    return result
+
+
+def check_app_pods(
+    v1: client.CoreV1Api,
+    config_apps: dict[str, dict[str, Any]],
+) -> CheckResult:
+    """Check pod readiness for each managed application namespace."""
+    result = CheckResult(name="App Pods", status=Status.OK)
+
+    # Collect unique namespaces from config (exclude system namespaces)
+    namespaces = {
+        app["destNamespace"]
+        for app in config_apps.values()
+        if app.get("destNamespace") not in (SYSTEM_NAMESPACE, ARGOCD_NAMESPACE)
+    }
+
+    for ns in sorted(namespaces):
+        try:
+            pods: list[V1Pod] = v1.list_namespaced_pod(
+                namespace=ns,
+                field_selector="status.phase!=Succeeded",
+            ).items
+        except ApiException as exc:
+            result.status = Status.WARN
+            result.details.append(f"{ns}: API error ({exc.reason})")
+            continue
+
+        if not pods:
+            continue
+
+        not_ready = []
+        for pod in pods:
+            pod_status = pod.status
+            conditions = (
+                pod_status.conditions if pod_status and pod_status.conditions else []
+            )
+            ready_cond = next((c for c in conditions if c.type == "Ready"), None)
+            if ready_cond and ready_cond.status != "True":
+                pod_name = pod.metadata.name if pod.metadata else "<unknown>"
+                not_ready.append(pod_name)
+
+        if not_ready:
+            result.status = Status.FAIL
+            result.details.append(
+                f"{ns}: {len(not_ready)} not-ready pod(s): " + ", ".join(not_ready)
+            )
+
+    if not result.details:
+        checked = len(namespaces)
+        result.details.append(f"All pods ready across {checked} namespace(s)")
+    return result
+
+
+def check_app_configs(config_apps: dict[str, dict[str, Any]]) -> CheckResult:
+    """Validate that deployed apps have config.json entries."""
+    result = CheckResult(name="App Config Coverage", status=Status.OK)
+
+    if not config_apps:
+        result.status = Status.WARN
+        result.details.append("No config.json files found")
+        return result
+
+    for name, cfg in config_apps.items():
+        missing_fields = [
+            f for f in ("appName", "destNamespace", "group", "wave") if f not in cfg
+        ]
+        if missing_fields:
+            result.status = Status.WARN
+            result.details.append(
+                f"{name}: missing fields: {', '.join(missing_fields)}"
+            )
+
+    if not result.details:
+        result.details.append(f"{len(config_apps)} app config(s) valid")
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Output
+# ---------------------------------------------------------------------------
+
+
+def print_report(report: Report) -> None:
+    """Print a human-readable report."""
+    divider = f"{_C.DIM}{'─' * 60}{_C.RESET}"
+    print()
+    print(f"{_C.BOLD}Health Check: {report.cluster_name}{_C.RESET}")
+    print(divider)
+
+    for result in report.results:
+        icon = _status_icon(result.status)
+        print(f"  {icon} {_C.BOLD}{result.name}{_C.RESET}")
+        for detail in result.details:
+            print(f"      {detail}")
+    print(divider)
+
+    label = {
+        Status.OK: f"{_C.GREEN}HEALTHY{_C.RESET}",
+        Status.WARN: f"{_C.YELLOW}DEGRADED{_C.RESET}",
+        Status.FAIL: f"{_C.RED}UNHEALTHY{_C.RESET}",
+        Status.SKIP: f"{_C.DIM}SKIPPED{_C.RESET}",
+    }[report.overall]
+    print(f"  Overall: {label}")
+    print()
+
+
+def print_json(report: Report) -> None:
+    """Print a machine-readable JSON report."""
+    output = {
+        "cluster": report.cluster_name,
+        "overall": report.overall.value,
+        "checks": [
+            {
+                "name": r.name,
+                "status": r.status.value,
+                "details": r.details,
+            }
+            for r in report.results
+        ],
+    }
+    print(json.dumps(output, indent=2))
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Health checks for Kubernetes cluster and Argo CD apps.",
+    )
+    parser.add_argument(
+        "--context",
+        default=None,
+        help="Kubernetes context to use (default: current context)",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="json_output",
+        help="Output report as JSON",
+    )
+    parser.add_argument(
+        "--namespace",
+        default=None,
+        help="Check only apps in this namespace",
+    )
+    parser.add_argument(
+        "--skip-nodes",
+        action="store_true",
+        help="Skip node health check",
+    )
+    parser.add_argument(
+        "--skip-argo",
+        action="store_true",
+        help="Skip Argo CD application check",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+
+    # Load kubeconfig
+    try:
+        config.load_kube_config(context=args.context)
+    except config.ConfigException as exc:
+        print(f"{_C.RED}Failed to load kubeconfig: {exc}{_C.RESET}", file=sys.stderr)
+        return 2
+
+    # Derive cluster name from current context
+    _, active_context = config.list_kube_config_contexts()
+    cluster_name = (
+        args.context or active_context.get("name", "unknown")
+        if active_context
+        else "unknown"
+    )
+
+    v1 = client.CoreV1Api()
+    custom_api = client.CustomObjectsApi()
+
+    # Load config files for cross-referencing
+    config_apps = _load_config_files()
+
+    # Filter by namespace if requested
+    if args.namespace:
+        config_apps = {
+            name: cfg
+            for name, cfg in config_apps.items()
+            if cfg.get("destNamespace") == args.namespace
+        }
+
+    # Build report
+    report = Report(cluster_name=cluster_name)
+
+    if not args.skip_nodes:
+        report.results.append(check_nodes(v1))
+
+    report.results.append(check_system_pods(v1))
+
+    if not args.skip_argo:
+        report.results.append(check_argo_apps(custom_api, config_apps))
+
+    report.results.append(check_app_pods(v1, config_apps))
+    report.results.append(check_app_configs(config_apps))
+
+    # Output
+    if args.json_output:
+        print_json(report)
+    else:
+        print_report(report)
+
+    return 1 if report.overall == Status.FAIL else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/health_check.py
+++ b/scripts/health_check.py
@@ -164,25 +164,75 @@ def check_nodes(v1: client.CoreV1Api) -> CheckResult:
     return result
 
 
+UNHEALTHY_CONTAINER_REASONS = frozenset(
+    {
+        "CrashLoopBackOff",
+        "ImagePullBackOff",
+        "ErrImagePull",
+        "InvalidImageName",
+        "CreateContainerConfigError",
+        "CreateContainerError",
+        "RunContainerError",
+        "PreStartHookError",
+        "ExceededGracePeriod",
+    }
+)
+
+
+def _container_has_issues(pod: V1Pod) -> list[str]:
+    """Return list of container status strings for unhealthy containers."""
+    issues: list[str] = []
+    if not pod.status:
+        return issues
+    for c in pod.status.container_statuses or []:
+        if (
+            c.state
+            and c.state.waiting
+            and c.state.waiting.reason in UNHEALTHY_CONTAINER_REASONS
+        ):
+            issues.append(f"{c.name}: {c.state.waiting.reason}")
+        if c.state and c.state.terminated and c.state.terminated.exit_code != 0:
+            issues.append(
+                f"{c.name}: {c.state.terminated.reason or 'exit code ' + str(c.state.terminated.exit_code)}"
+            )
+    for c in pod.status.init_container_statuses or []:
+        if (
+            c.state
+            and c.state.waiting
+            and c.state.waiting.reason in UNHEALTHY_CONTAINER_REASONS
+        ):
+            issues.append(f"{c.name}: {c.state.waiting.reason}")
+    return issues
+
+
 def check_system_pods(v1: client.CoreV1Api) -> CheckResult:
     """Check that kube-system pods are running and ready."""
     result = CheckResult(name="System Pods", status=Status.OK)
     try:
         pods: list[V1Pod] = v1.list_namespaced_pod(
             namespace=SYSTEM_NAMESPACE,
-            field_selector="status.phase!=Running,status.phase!=Succeeded",
         ).items
     except ApiException as exc:
         result.status = Status.FAIL
         result.details.append(f"API error: {exc.reason}")
         return result
 
-    if pods:
+    unhealthy: list[str] = []
+    for pod in pods:
+        phase = pod.status.phase if pod.status else "Unknown"
+        pod_name = pod.metadata.name if pod.metadata else "<unknown>"
+        if phase == "Succeeded":
+            continue
+        if phase not in ("Running",):
+            unhealthy.append(f"{pod_name}: phase={phase}")
+            continue
+        container_issues = _container_has_issues(pod)
+        if container_issues:
+            unhealthy.append(f"{pod_name}: {', '.join(container_issues)}")
+
+    if unhealthy:
         result.status = Status.FAIL
-        for pod in pods:
-            phase = pod.status.phase if pod.status else "Unknown"
-            pod_name = pod.metadata.name if pod.metadata else "<unknown>"
-            result.details.append(f"{pod_name}: {phase}")
+        result.details.extend(unhealthy)
     else:
         result.details.append(f"All pods running in {SYSTEM_NAMESPACE}")
     return result
@@ -261,12 +311,12 @@ def check_app_pods(
 
     # Collect unique namespaces from config (exclude system namespaces)
     namespaces = {
-        app["destNamespace"]
+        app.get("destNamespace")
         for app in config_apps.values()
-        if app.get("destNamespace") not in (SYSTEM_NAMESPACE, ARGOCD_NAMESPACE)
+        if app.get("destNamespace") not in (SYSTEM_NAMESPACE, ARGOCD_NAMESPACE, None)
     }
 
-    for ns in sorted(namespaces):
+    for ns in sorted(ns for ns in namespaces if ns is not None):
         try:
             pods: list[V1Pod] = v1.list_namespaced_pod(
                 namespace=ns,


### PR DESCRIPTION
- **feat(health): add Kubernetes and Argo CD health check script**
- **fix(ansible): rename prod_k8s_agents group to prod_k8s_agent**
- **fix(ansible): add play-level tags to all plays in homelab.yaml**
- **fix(ansible): quote mode values with double quotes in _k3s_prereq tasks**
- **fix(ansible): use ansible_facts dict access instead of deprecated top-level fact injection**
- **fix(ansible): disable IPv6 NDisc and keep routes in dhcp.network**
- **fix(ansible): remove legacy tailscale.list if tailscale.sources exists**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added health checks for Kubernetes nodes, system pods, applications, and configurations.
  - Health reports are available in readable text or JSON format, with filtering and skip options.
  - Added task commands for running health checks.
  - Added tags for selectively running infrastructure playbooks.

- **Improvements**
  - Improved IPv4 and IPv6 network configuration and persistence.
  - Updated Kubernetes and networking compatibility handling.
  - Improved Tailscale package source migration.

- **Maintenance**
  - Updated infrastructure collection versions and corrected Kubernetes agent inventory naming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->