### PR TITLE
fix/radarr tailscale

### DIFF
--- a/kubernetes/main/apps/downloads/prowlarr/base/volsync-replication-destination.yaml
+++ b/kubernetes/main/apps/downloads/prowlarr/base/volsync-replication-destination.yaml
@@ -19,6 +19,9 @@ spec:
     accessModes:
       - ReadWriteOnce
     capacity: 5Gi
+    resources:
+      limits:
+        memory: 1Gi
     moverSecurityContext:
       runAsUser: 65534
       runAsGroup: 65534

--- a/kubernetes/main/apps/downloads/prowlarr/base/volsync-replication-source.yaml
+++ b/kubernetes/main/apps/downloads/prowlarr/base/volsync-replication-source.yaml
@@ -24,5 +24,8 @@ spec:
       runAsUser: 1001
       runAsGroup: 1001
       fsGroup: 1001
+    resources:
+      limits:
+        memory: 1Gi
     retain:
       daily: 7

--- a/kubernetes/main/apps/downloads/radarr/base/volsync-replication-destination.yaml
+++ b/kubernetes/main/apps/downloads/radarr/base/volsync-replication-destination.yaml
@@ -19,6 +19,9 @@ spec:
     accessModes:
       - ReadWriteOnce
     capacity: 20Gi
+    resources:
+      limits:
+        memory: 1Gi
     moverSecurityContext:
       runAsUser: 65534
       runAsGroup: 65534

--- a/kubernetes/main/apps/downloads/radarr/base/volsync-replication-source.yaml
+++ b/kubernetes/main/apps/downloads/radarr/base/volsync-replication-source.yaml
@@ -24,5 +24,8 @@ spec:
       runAsUser: 1001
       runAsGroup: 1001
       fsGroup: 1001
+    resources:
+      limits:
+        memory: 1Gi
     retain:
       daily: 7

--- a/kubernetes/main/apps/downloads/radarr/values.yaml
+++ b/kubernetes/main/apps/downloads/radarr/values.yaml
@@ -52,8 +52,7 @@ controllers:
               secretKeyRef:
                 name: tailscale-auth
                 key: TS_AUTHKEY
-          TS_EXTRA_ARGS: "--login-server=https://weasel.stoneydavis.com --hostname=radarr
-            --ephemeral"
+          TS_EXTRA_ARGS: "--login-server=https://weasel.stoneydavis.com --hostname=radarr"
           TS_KUBE_SECRET: ""
           TS_USERSPACE: "true"
           TS_STATE_DIR: "/tmp/tailscale/state"

--- a/kubernetes/main/apps/downloads/readarr/volsync-replication-destination.yaml
+++ b/kubernetes/main/apps/downloads/readarr/volsync-replication-destination.yaml
@@ -19,3 +19,6 @@ spec:
     accessModes:
       - ReadWriteOnce
     capacity: 5Gi
+    resources:
+      limits:
+        memory: 1Gi

--- a/kubernetes/main/apps/downloads/readarr/volsync-replication-source.yaml
+++ b/kubernetes/main/apps/downloads/readarr/volsync-replication-source.yaml
@@ -24,5 +24,8 @@ spec:
       runAsUser: 1001
       runAsGroup: 1001
       fsGroup: 1001
+    resources:
+      limits:
+        memory: 1Gi
     retain:
       daily: 7

--- a/kubernetes/main/apps/downloads/recyclarr/volsync-replication-destination.yaml
+++ b/kubernetes/main/apps/downloads/recyclarr/volsync-replication-destination.yaml
@@ -19,3 +19,6 @@ spec:
     accessModes:
       - ReadWriteOnce
     capacity: 5Gi
+    resources:
+      limits:
+        memory: 1Gi

--- a/kubernetes/main/apps/downloads/recyclarr/volsync-replication-source.yaml
+++ b/kubernetes/main/apps/downloads/recyclarr/volsync-replication-source.yaml
@@ -24,5 +24,8 @@ spec:
       runAsUser: 1001
       runAsGroup: 1001
       fsGroup: 1001
+    resources:
+      limits:
+        memory: 1Gi
     retain:
       daily: 7

--- a/kubernetes/main/apps/downloads/rtorrent/volsync-replication-destination.yaml
+++ b/kubernetes/main/apps/downloads/rtorrent/volsync-replication-destination.yaml
@@ -19,3 +19,6 @@ spec:
     accessModes:
       - ReadWriteOnce
     capacity: 5Gi
+    resources:
+      limits:
+        memory: 1Gi

--- a/kubernetes/main/apps/downloads/rtorrent/volsync-replication-source.yaml
+++ b/kubernetes/main/apps/downloads/rtorrent/volsync-replication-source.yaml
@@ -24,5 +24,8 @@ spec:
       runAsUser: 1001
       runAsGroup: 1001
       fsGroup: 1001
+    resources:
+      limits:
+        memory: 1Gi
     retain:
       daily: 7

--- a/kubernetes/main/apps/downloads/sonarr/pvc/config/volsync-replication-destination.yaml
+++ b/kubernetes/main/apps/downloads/sonarr/pvc/config/volsync-replication-destination.yaml
@@ -19,3 +19,6 @@ spec:
     accessModes:
       - ReadWriteMany
     capacity: 2Gi
+    resources:
+      limits:
+        memory: 1Gi

--- a/kubernetes/main/apps/downloads/sonarr/pvc/config/volsync-replication-source.yaml
+++ b/kubernetes/main/apps/downloads/sonarr/pvc/config/volsync-replication-source.yaml
@@ -24,5 +24,8 @@ spec:
       runAsUser: 1001
       runAsGroup: 1001
       fsGroup: 1001
+    resources:
+      limits:
+        memory: 1Gi
     retain:
       daily: 7

--- a/kubernetes/main/apps/downloads/unpackerr/volsync-replication-destination.yaml
+++ b/kubernetes/main/apps/downloads/unpackerr/volsync-replication-destination.yaml
@@ -19,3 +19,6 @@ spec:
     accessModes:
       - ReadWriteOnce
     capacity: 5Gi
+    resources:
+      limits:
+        memory: 1Gi

--- a/kubernetes/main/apps/downloads/unpackerr/volsync-replication-source.yaml
+++ b/kubernetes/main/apps/downloads/unpackerr/volsync-replication-source.yaml
@@ -24,5 +24,8 @@ spec:
       runAsUser: 1001
       runAsGroup: 1001
       fsGroup: 1001
+    resources:
+      limits:
+        memory: 1Gi
     retain:
       daily: 7

--- a/kubernetes/main/apps/downloads/whisparr/volsync-replication-destination.yaml
+++ b/kubernetes/main/apps/downloads/whisparr/volsync-replication-destination.yaml
@@ -19,3 +19,6 @@ spec:
     accessModes:
       - ReadWriteOnce
     capacity: 5Gi
+    resources:
+      limits:
+        memory: 1Gi

--- a/kubernetes/main/apps/downloads/whisparr/volsync-replication-source.yaml
+++ b/kubernetes/main/apps/downloads/whisparr/volsync-replication-source.yaml
@@ -24,5 +24,8 @@ spec:
       runAsUser: 1001
       runAsGroup: 1001
       fsGroup: 1001
+    resources:
+      limits:
+        memory: 1Gi
     retain:
       daily: 7

--- a/kubernetes/main/apps/media/jellyfin/base/pvc/config/volsync-replication-destination.yaml
+++ b/kubernetes/main/apps/media/jellyfin/base/pvc/config/volsync-replication-destination.yaml
@@ -19,6 +19,9 @@ spec:
     accessModes:
       - ReadWriteOnce
     capacity: 1Gi
+    resources:
+      limits:
+        memory: 1Gi
     moverSecurityContext:
       runAsUser: 65534
       runAsGroup: 65534

--- a/kubernetes/main/apps/media/jellyfin/base/pvc/config/volsync-replication-source.yaml
+++ b/kubernetes/main/apps/media/jellyfin/base/pvc/config/volsync-replication-source.yaml
@@ -27,5 +27,8 @@ spec:
       runAsNonRoot: true
       seccompProfile:
         type: RuntimeDefault
+    resources:
+      limits:
+        memory: 1Gi
     retain:
       daily: 7

--- a/kubernetes/main/apps/media/plex/pvc/cache/volsync-replication-destination.yaml
+++ b/kubernetes/main/apps/media/plex/pvc/cache/volsync-replication-destination.yaml
@@ -15,6 +15,9 @@ spec:
     cleanupTempPVC: true
     enableFileDeletion: true
     capacity: 1Gi
+    resources:
+      limits:
+        memory: 1Gi
     cacheStorageClassName: openebs-hostpath
     cacheAccessModes:
       - ReadWriteOnce

--- a/kubernetes/main/apps/media/plex/pvc/cache/volsync-replication-source.yaml
+++ b/kubernetes/main/apps/media/plex/pvc/cache/volsync-replication-source.yaml
@@ -24,5 +24,8 @@ spec:
       runAsUser: 1001
       runAsGroup: 1001
       fsGroup: 1001
+    resources:
+      limits:
+        memory: 1Gi
     retain:
       daily: 7

--- a/kubernetes/main/apps/media/plex/pvc/config/volsync-replication-destination.yaml
+++ b/kubernetes/main/apps/media/plex/pvc/config/volsync-replication-destination.yaml
@@ -19,3 +19,6 @@ spec:
     accessModes:
       - ReadWriteOnce
     capacity: 1Gi
+    resources:
+      limits:
+        memory: 1Gi

--- a/kubernetes/main/apps/media/plex/pvc/config/volsync-replication-source.yaml
+++ b/kubernetes/main/apps/media/plex/pvc/config/volsync-replication-source.yaml
@@ -24,5 +24,8 @@ spec:
       runAsUser: 1001
       runAsGroup: 1001
       fsGroup: 1001
+    resources:
+      limits:
+        memory: 1Gi
     retain:
       daily: 7

--- a/kubernetes/main/apps/media/spotizerr/base/pvc/config/volsync-replication-destination.yaml
+++ b/kubernetes/main/apps/media/spotizerr/base/pvc/config/volsync-replication-destination.yaml
@@ -19,6 +19,9 @@ spec:
     accessModes:
       - ReadWriteOnce
     capacity: 1Gi
+    resources:
+      limits:
+        memory: 1Gi
     moverSecurityContext:
       runAsUser: 65534
       runAsGroup: 65534

--- a/kubernetes/main/apps/media/spotizerr/base/pvc/config/volsync-replication-source.yaml
+++ b/kubernetes/main/apps/media/spotizerr/base/pvc/config/volsync-replication-source.yaml
@@ -27,5 +27,8 @@ spec:
       runAsNonRoot: true
       seccompProfile:
         type: RuntimeDefault
+    resources:
+      limits:
+        memory: 1Gi
     retain:
       daily: 7

--- a/kubernetes/main/apps/media/spotizerr/base/pvc/data/volsync-replication-destination.yaml
+++ b/kubernetes/main/apps/media/spotizerr/base/pvc/data/volsync-replication-destination.yaml
@@ -19,6 +19,9 @@ spec:
     accessModes:
       - ReadWriteOnce
     capacity: 1Gi
+    resources:
+      limits:
+        memory: 1Gi
     moverSecurityContext:
       runAsUser: 65534
       runAsGroup: 65534

--- a/kubernetes/main/apps/media/spotizerr/base/pvc/data/volsync-replication-source.yaml
+++ b/kubernetes/main/apps/media/spotizerr/base/pvc/data/volsync-replication-source.yaml
@@ -27,5 +27,8 @@ spec:
       runAsNonRoot: true
       seccompProfile:
         type: RuntimeDefault
+    resources:
+      limits:
+        memory: 1Gi
     retain:
       daily: 7

--- a/kubernetes/main/apps/media/spotizerr/base/pvc/progress/volsync-replication-destination.yaml
+++ b/kubernetes/main/apps/media/spotizerr/base/pvc/progress/volsync-replication-destination.yaml
@@ -19,6 +19,9 @@ spec:
     accessModes:
       - ReadWriteOnce
     capacity: 1Gi
+    resources:
+      limits:
+        memory: 1Gi
     moverSecurityContext:
       runAsUser: 65534
       runAsGroup: 65534

--- a/kubernetes/main/apps/media/spotizerr/base/pvc/progress/volsync-replication-source.yaml
+++ b/kubernetes/main/apps/media/spotizerr/base/pvc/progress/volsync-replication-source.yaml
@@ -27,5 +27,8 @@ spec:
       runAsNonRoot: true
       seccompProfile:
         type: RuntimeDefault
+    resources:
+      limits:
+        memory: 1Gi
     retain:
       daily: 7

--- a/kubernetes/main/apps/selfhosted/immich/base/volsync-replication-destination.yaml
+++ b/kubernetes/main/apps/selfhosted/immich/base/volsync-replication-destination.yaml
@@ -19,6 +19,9 @@ spec:
     accessModes:
       - ReadWriteMany
     capacity: 5Gi
+    resources:
+      limits:
+        memory: 1Gi
     moverSecurityContext:
       runAsUser: 65534
       runAsGroup: 65534

--- a/kubernetes/main/apps/selfhosted/immich/base/volsync-replication-source.yaml
+++ b/kubernetes/main/apps/selfhosted/immich/base/volsync-replication-source.yaml
@@ -24,5 +24,8 @@ spec:
       runAsUser: 1001
       runAsGroup: 1001
       fsGroup: 1001
+    resources:
+      limits:
+        memory: 1Gi
     retain:
       daily: 7

--- a/kubernetes/main/apps/selfhosted/lemonldap/volsync-replication-destination.yaml
+++ b/kubernetes/main/apps/selfhosted/lemonldap/volsync-replication-destination.yaml
@@ -19,6 +19,9 @@ spec:
     accessModes:
       - ReadWriteOnce
     capacity: 5Gi
+    resources:
+      limits:
+        memory: 1Gi
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/volsync.backube/replicationdestination_v1alpha1.json
 apiVersion: volsync.backube/v1alpha1
@@ -40,6 +43,9 @@ spec:
     accessModes:
       - ReadWriteOnce
     capacity: 5Gi
+    resources:
+      limits:
+        memory: 1Gi
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/volsync.backube/replicationdestination_v1alpha1.json
 apiVersion: volsync.backube/v1alpha1
@@ -61,6 +67,9 @@ spec:
     accessModes:
       - ReadWriteOnce
     capacity: 5Gi
+    resources:
+      limits:
+        memory: 1Gi
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/volsync.backube/replicationdestination_v1alpha1.json
 apiVersion: volsync.backube/v1alpha1
@@ -82,3 +91,6 @@ spec:
     accessModes:
       - ReadWriteOnce
     capacity: 5Gi
+    resources:
+      limits:
+        memory: 1Gi

--- a/kubernetes/main/apps/selfhosted/lemonldap/volsync-replication-source.yaml
+++ b/kubernetes/main/apps/selfhosted/lemonldap/volsync-replication-source.yaml
@@ -24,6 +24,9 @@ spec:
       runAsUser: 1001
       runAsGroup: 1001
       fsGroup: 1001
+    resources:
+      limits:
+        memory: 1Gi
     retain:
       daily: 7
 ---
@@ -52,6 +55,9 @@ spec:
       runAsUser: 1001
       runAsGroup: 1001
       fsGroup: 1001
+    resources:
+      limits:
+        memory: 1Gi
     retain:
       daily: 7
 ---
@@ -80,6 +86,9 @@ spec:
       runAsUser: 1001
       runAsGroup: 1001
       fsGroup: 1001
+    resources:
+      limits:
+        memory: 1Gi
     retain:
       daily: 7
 ---
@@ -108,5 +117,8 @@ spec:
       runAsUser: 1001
       runAsGroup: 1001
       fsGroup: 1001
+    resources:
+      limits:
+        memory: 1Gi
     retain:
       daily: 7

--- a/kubernetes/main/apps/selfhosted/timetagger/base/volsync-replication-destination.yaml
+++ b/kubernetes/main/apps/selfhosted/timetagger/base/volsync-replication-destination.yaml
@@ -19,6 +19,9 @@ spec:
     accessModes:
       - ReadWriteOnce
     capacity: 5Gi
+    resources:
+      limits:
+        memory: 1Gi
     moverSecurityContext:
       runAsUser: 65534
       runAsGroup: 65534

--- a/kubernetes/main/apps/selfhosted/timetagger/base/volsync-replication-source.yaml
+++ b/kubernetes/main/apps/selfhosted/timetagger/base/volsync-replication-source.yaml
@@ -27,5 +27,8 @@ spec:
       runAsNonRoot: true
       seccompProfile:
         type: RuntimeDefault
+    resources:
+      limits:
+        memory: 1Gi
     retain:
       daily: 7

--- a/kubernetes/main/templates/volsync/backblaze.yaml
+++ b/kubernetes/main/templates/volsync/backblaze.yaml
@@ -49,6 +49,9 @@ spec:
       runAsUser: 1001
       runAsGroup: 1001
       fsGroup: 1001
+    resources:
+      limits:
+        memory: 1Gi
     retain:
       daily: 7
 ---
@@ -68,6 +71,9 @@ spec:
     cacheAccessModes:
       - "${VOLSYNC_CACHE_ACCESSMODES:-ReadWriteOnce}"
     cacheCapacity: 1Gi
+    resources:
+      limits:
+        memory: 1Gi
     storageClassName: "${VOLSYNC_STORAGECLASS:-ceph-block}"
     accessModes:
       - "${VOLSYNC_ACCESSMODES:-ReadWriteOnce}"

--- a/kubernetes/main/templates/volsync/r2.yaml
+++ b/kubernetes/main/templates/volsync/r2.yaml
@@ -49,5 +49,8 @@ spec:
       runAsUser: 1001
       runAsGroup: 1001
       fsGroup: 1001
+    resources:
+      limits:
+        memory: 1Gi
     retain:
       daily: 7


### PR DESCRIPTION
- **fix(radarr): remove deprecated --ephemeral flag from tailscale sidecar**
- **feat(volsync): add 1Gi memory limits to all restic mover pods**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a 1 GiB memory limit to backup and restore operations across supported applications, improving resource predictability and reducing the risk of excessive memory usage.
  * Updated Radarr’s Tailscale configuration to retain its hostname and login server settings without using ephemeral authentication.

* **Reliability**
  * Standardized memory controls across application replication workflows and shared backup templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->