### PR TITLE
fix(jellyfin): correct volsync sourcePVC name and add fsGroupChangePolicy

### DIFF
--- a/kubernetes/main/apps/media/jellyfin/base/pvc/config/volsync-replication-source.yaml
+++ b/kubernetes/main/apps/media/jellyfin/base/pvc/config/volsync-replication-source.yaml
@@ -5,7 +5,7 @@ kind: ReplicationSource
 metadata:
   name: jellyfin-config-backblaze
 spec:
-  sourcePVC: jellyfin-config
+  sourcePVC: jellyfin
   trigger:
     schedule: 0 0 * * *
   restic:
@@ -24,6 +24,7 @@ spec:
       runAsUser: 1001
       runAsGroup: 1001
       fsGroup: 1001
+      fsGroupChangePolicy: OnRootMismatch
       runAsNonRoot: true
       seccompProfile:
         type: RuntimeDefault


### PR DESCRIPTION
- sourcePVC jellyfin-config -> jellyfin (matches actual PVC name from app-template chart)
- Add fsGroupChangePolicy: OnRootMismatch to mover security context to prevent
  long chown stalls on large Ceph RBD volumes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Jellyfin configuration replication to use the correct source.
  * Improved backup handling by applying the appropriate filesystem group policy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->