### PR TITLE
fix(jellyfin): reduce volsync mover memory to 1Gi and add RESTIC_PACK_SIZE=256

### DIFF
--- a/kubernetes/main/apps/media/jellyfin/base/pvc/config/volsync-external-secret.yaml
+++ b/kubernetes/main/apps/media/jellyfin/base/pvc/config/volsync-external-secret.yaml
@@ -17,6 +17,7 @@ spec:
         RESTIC_PASSWORD: "{{ .RESTIC_PASSWORD }}"
         AWS_ACCESS_KEY_ID: "{{ .AWS_ACCESS_KEY_ID }}"
         AWS_SECRET_ACCESS_KEY: "{{ .AWS_SECRET_ACCESS_KEY }}"
+        RESTIC_PACK_SIZE: "256"
   data:
     - secretKey: REPOSITORY_TEMPLATE
       remoteRef:

--- a/kubernetes/main/apps/media/jellyfin/base/pvc/config/volsync-replication-source.yaml
+++ b/kubernetes/main/apps/media/jellyfin/base/pvc/config/volsync-replication-source.yaml
@@ -30,6 +30,6 @@ spec:
         type: RuntimeDefault
     moverResources:
       limits:
-        memory: 20Gi
+        memory: 1Gi
     retain:
       daily: 7


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Optimized Jellyfin configuration backups by setting the Restic pack size to 256.
  * Reduced memory allocation for the backup replication process from 20 GiB to 1 GiB.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->