### PR TITLE
fix(rook-ceph): add toleration for dedicated=gpu taint on panda node

### DIFF
--- a/kubernetes/main/apps/storage/rook-ceph-cluster/rook-ceph-cluster-values.yaml
+++ b/kubernetes/main/apps/storage/rook-ceph-cluster/rook-ceph-cluster-values.yaml
@@ -37,6 +37,13 @@ cephClusterSpec:
   disruptionManagement:
     managePodBudgets: false
   removeOSDsIfOutAndSafeToRemove: true
+  placement:
+    all:
+      tolerations:
+        - key: dedicated
+          operator: Equal
+          value: gpu
+          effect: NoExecute
 cephFileSystemVolumeSnapshotClass:
   enabled: true
 cephBlockPoolsVolumeSnapshotClass:


### PR DESCRIPTION
rook-ceph-mon-k was stuck Pending because the rook operator pinned it
to node panda (via nodeSelector) but the pod had no toleration for
panda's dedicated=gpu:NoExecute taint. Add a placement.all toleration
to the CephCluster spec so all rook daemons can schedule on panda.
