### PR TITLE
fix: add dedicated=gpu:NoExecute tolerations for all CSI/node daemonsets

### DIFF
--- a/kubernetes/main/apps/storage/csi-driver-nfs/values.yaml
+++ b/kubernetes/main/apps/storage/csi-driver-nfs/values.yaml
@@ -2,6 +2,11 @@
 controller:
   replicas: 1
   dnsPolicy: Default
+  tolerations:
+    - key: dedicated
+      operator: Equal
+      value: gpu
+      effect: NoExecute
 storageClasses:
   - name: nfs-ip
     parameters:
@@ -22,3 +27,5 @@ storageClasses:
 
 node:
   dnsPolicy: Default
+  tolerations:
+    - operator: Exists

--- a/kubernetes/main/apps/storage/openebs/values.yaml
+++ b/kubernetes/main/apps/storage/openebs/values.yaml
@@ -6,6 +6,11 @@ localpv-provisioner:
     image:
       registry: quay.io/
       repository: openebs/provisioner-localpv
+    tolerations:
+      - key: dedicated
+        operator: Equal
+        value: gpu
+        effect: NoExecute
   hostpathClass:
     enabled: true
     name: openebs-hostpath

--- a/kubernetes/main/apps/storage/rook-ceph-operator/values.yaml
+++ b/kubernetes/main/apps/storage/rook-ceph-operator/values.yaml
@@ -7,3 +7,13 @@ csi:
   disableHolderPods: true
   enableCSIHostNetwork: true
   enableVolumeGroupSnapshot: false
+  pluginTolerations:
+    - key: dedicated
+      operator: Equal
+      value: gpu
+      effect: NoExecute
+  provisionerTolerations:
+    - key: dedicated
+      operator: Equal
+      value: gpu
+      effect: NoExecute

--- a/kubernetes/main/apps/system/metallb/values.yaml
+++ b/kubernetes/main/apps/system/metallb/values.yaml
@@ -9,3 +9,15 @@ prometheus:
     enabled: false
   prometheusRule:
     enabled: true
+speaker:
+  tolerations:
+    - key: dedicated
+      operator: Equal
+      value: gpu
+      effect: NoExecute
+controller:
+  tolerations:
+    - key: dedicated
+      operator: Equal
+      value: gpu
+      effect: NoExecute


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated storage and networking components to tolerate designated GPU-node taints.
  * Enabled NFS CSI, OpenEBS, Rook Ceph, and MetalLB components to run on appropriately dedicated GPU nodes.
  * Improved workload scheduling flexibility for clusters with tainted GPU infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->