### PR TITLE
fix(immich): use onepassword store for cnpg db credentials

### DIFF
--- a/kubernetes/main/apps/selfhosted/immich/base/external-secret.yaml
+++ b/kubernetes/main/apps/selfhosted/immich/base/external-secret.yaml
@@ -26,7 +26,7 @@ spec:
   refreshInterval: 24h
   secretStoreRef:
     kind: ClusterSecretStore
-    name: crunchy-pgo-secrets
+    name: onepassword-connect
   target:
     name: immich-db-secret
     creationPolicy: Owner


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Immich database secret retrieval to use the correct secret store, improving reliability during deployment and operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->