### PR TITLE
fix(immich): add fsGroup to pod securityContext for CephFS volume permissions

### DIFF
--- a/kubernetes/main/apps/selfhosted/immich/immich-values.yaml
+++ b/kubernetes/main/apps/selfhosted/immich/immich-values.yaml
@@ -3,6 +3,8 @@ controllers:
   main:
     pod:
       securityContext:
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
         seccompProfile:
           type: RuntimeDefault
     containers:


### PR DESCRIPTION
## Summary
Added `fsGroup: 1000` and `fsGroupChangePolicy: OnRootMismatch` to the immich-server pod securityContext to fix the `EACCES` permission error when writing to the `/data` volume mount.

## Problem
After upgrading immich to v3.0.0 with a database restored from v1.126.1, the server was crash-looping with:
```
Failed to write /data/encoded-video/.immich: Error: EACCES: permission denied, open '/data/encoded-video/.immich'
```

The CephFS volume had files owned by `nobody:nogroup` (uid/gid 65534) due to the volsync restore, and the immich-server (uid 1000) couldn't write to the media directories.

## Solution
Added `fsGroup: 1000` to the pod securityContext, which instructs the Rook CephFS CSI driver to perform a recursive `chown` at mount time, correcting the ownership to uid 1000:1000. This matches the established pattern used by other CephFS media apps in this repo (radarr, sonarr, plex, etc.).

## Changes
- `kubernetes/main/apps/selfhosted/immich/immich-values.yaml`: Added `fsGroup: 1000` and `fsGroupChangePolicy: OnRootMismatch` to the pod securityContext

## Verification
- immich-server is now running healthy on v3.0.0
- All mount checks pass (thumbs, upload, backups, library, profile, encoded-video)
- Machine learning server is healthy
- Geodata import completed successfully

## Related
- Part of the immich v3.0.0 upgrade from v1.126.1
- Previous PR: #1422 (feat(immich): enable immich helm chart)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Immich storage access by applying consistent filesystem group permissions.
  * Reduced unnecessary permission updates when the existing root directory already matches the expected configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->