### PR TITLE
fix(jellyfin): pin image to stable 10.11.11

### DIFF
--- a/kubernetes/main/apps/media/jellyfin/values.yaml
+++ b/kubernetes/main/apps/media/jellyfin/values.yaml
@@ -28,7 +28,7 @@ controllers:
         image:
           repository: docker.io/jellyfin/jellyfin
           # renovate: datasource=docker depName=docker.io/jellyfin/jellyfin
-          tag: "2025122905"
+          tag: "10.11.11"
         env:
           TZ: "UTC"
           JELLYFIN_CACHE_DIR: "/config/cache"


### PR DESCRIPTION
The 10.12 nightly (2025122905) crash-loops during startup migration
with ObjectDisposedException on LoggerFactory (jellyfin#15571/#16100).
Pin to stable 10.11.11 which has mature EF Core migration code.
