### PR TITLE
fix(rook-ceph): bump charts v1.18.4 → v1.19.8

### DIFF
--- a/kubernetes/main/apps/storage/rook-ceph-cluster/kustomization.yaml
+++ b/kubernetes/main/apps/storage/rook-ceph-cluster/kustomization.yaml
@@ -14,7 +14,7 @@ helmCharts:
     releaseName: rook-ceph-cluster
     namespace: rook-ceph
     repo: https://charts.rook.io/release
-    version: v1.18.4
+    version: v1.19.8
     valuesFile: rook-ceph-cluster-values.yaml
 resources:
   - ./dashboard-external-http.yaml

--- a/kubernetes/main/apps/storage/rook-ceph-operator/kustomization.yaml
+++ b/kubernetes/main/apps/storage/rook-ceph-operator/kustomization.yaml
@@ -7,5 +7,5 @@ helmCharts:
     includeCRDs: true
     releaseName: rook-ceph
     repo: https://charts.rook.io/release
-    version: v1.18.4
+    version: v1.19.8
     valuesFile: values.yaml


### PR DESCRIPTION
## What

Step 1 of the two-part Rook upgrade path toward PR #781's target v1.20.3.

Rook's [v1.20 upgrade guide](https://rook.io/docs/rook/latest/ceph-upgrade.html) requires v1.19.5+ before upgrading to v1.20. A direct v1.18.4 → v1.20.3 jump is unsupported. This PR lands the cluster on the latest v1.19.x patch as the intermediate step.

## Changes

- **Operator chart:** v1.18.4 → v1.19.8
- **Cluster chart:** v1.18.4 → v1.19.8
- **Bundled ceph-csi-operator:** 0.4.1 → 0.6.0

No values.yaml changes required — all  keys are still honored in v1.19.

## Expected cluster effects

| Component | Before | After |
|-----------|--------|-------|
| Rook operator | v1.18.4 | v1.19.8 |
| ceph-csi-operator | v0.4.1 | v0.6.0 |
| Ceph daemons | v19.2.3 | v19.2.4 (chart default) |
| CephCluster CRDs | v1.18 | v1.19 |

- Operator + CSI pods roll during Argo sync
- Ceph daemons do a patch-level rolling restart (v19.2.3 → v19.2.4)
- GPU tolerations on CSI pods preserved (verified via helm template render)

## Validation

-  ✓ (both dirs)
-  ✓ (all 67 trees)
- don't commit to branch...................................................Passed
check json...............................................................Passed
check json...........................................(no files to check)Skipped
check for merge conflicts................................................Passed
check toml...............................................................Passed
check yaml...............................................................Passed
trim trailing whitespace.................................................Passed
check for broken symlinks............................(no files to check)Skipped
check builtin type constructor use.......................................Passed
check python ast.........................................................Passed
check for added large files..............................................Passed
debug statements (python)................................................Passed
mixed line ending........................................................Passed
fix requirements.txt.................................(no files to check)Skipped
Validate GitHub Workflows................................................Passed
Validate GitHub Actions..............................(no files to check)Skipped
Validate Dependabot Config (v2)......................(no files to check)Skipped
Validate Taskfile Config.................................................Passed
Validate Renovate Config.................................................Passed
mdformat.................................................................Passed
cspell...................................................................Passed
yamlfmt..................................................................Failed
- hook id: yamlfmt
- files were modified by this hook
yamllint.................................................................Passed
biome check..............................................................Passed
- hook id: local-biome-check
- duration: 3.58s

Checked 4 files in 22ms. No fixes applied.
Checked 4 files in 9ms. No fixes applied.
Checked 4 files in 6ms. No fixes applied.
Checked 4 files in 15ms. No fixes applied.
Checked 4 files in 12ms. No fixes applied.
Checked 4 files in 9ms. No fixes applied.
Checked 4 files in 7ms. No fixes applied.
Checked 4 files in 11ms. No fixes applied.
Checked 4 files in 6ms. No fixes applied.
Checked 4 files in 12ms. No fixes applied.
Checked 4 files in 11ms. No fixes applied.
Checked 4 files in 6ms. No fixes applied.
Checked 4 files in 14ms. No fixes applied.
Checked 4 files in 5ms. No fixes applied.
Checked 4 files in 8ms. No fixes applied.

config.json check........................................................Passed
uv-lock..................................................................Passed ✓

## Next steps

After this merges:
1. Verify operator/csi pods healthy,  HEALTH_OK
2. Renovate will rebase #781 onto v1.19.8 base — rework that as PR B for the v1.19 → v1.20.3 migration + ceph-csi-drivers chart + csi.* values removal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Rook Ceph storage components to version 1.19.8.
  * Includes the latest upstream improvements and fixes from the updated chart release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->