### PR TITLE
Rook: Bump operator and cluster charts from v1.19.8 to v1.20.3

### DIFF
--- a/kubernetes/main/apps/storage/rook-ceph-cluster/kustomization.yaml
+++ b/kubernetes/main/apps/storage/rook-ceph-cluster/kustomization.yaml
@@ -14,7 +14,7 @@ helmCharts:
     releaseName: rook-ceph-cluster
     namespace: rook-ceph
     repo: https://charts.rook.io/release
-    version: v1.19.8
+    version: v1.20.3
     valuesFile: rook-ceph-cluster-values.yaml
 resources:
   - ./dashboard-external-http.yaml

--- a/kubernetes/main/apps/storage/rook-ceph-cluster/rook-ceph-cluster-values.yaml
+++ b/kubernetes/main/apps/storage/rook-ceph-cluster/rook-ceph-cluster-values.yaml
@@ -4,6 +4,8 @@ monitoring:
   createPrometheusRules: true
 toolbox:
   enabled: true
+cephImage:
+  tag: v20.2.2
 cephClusterSpec:
   resources:
     mgr:

--- a/kubernetes/main/apps/storage/rook-ceph-operator/ceph-csi-operator-config.yaml
+++ b/kubernetes/main/apps/storage/rook-ceph-operator/ceph-csi-operator-config.yaml
@@ -2,7 +2,7 @@
 apiVersion: csi.ceph.io/v1
 kind: OperatorConfig
 metadata:
-  name: rook-ceph
+  name: ceph-csi-operator-config
   namespace: rook-ceph
 spec:
   driverSpecDefaults:

--- a/kubernetes/main/apps/storage/rook-ceph-operator/ceph-csi-operator-config.yaml
+++ b/kubernetes/main/apps/storage/rook-ceph-operator/ceph-csi-operator-config.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: csi.ceph.io/v1
+kind: OperatorConfig
+metadata:
+  name: rook-ceph
+  namespace: rook-ceph
+spec:
+  driverSpecDefaults:
+    controllerPlugin:
+      tolerations:
+        - key: dedicated
+          operator: Equal
+          value: gpu
+          effect: NoExecute
+    nodePlugin:
+      tolerations:
+        - key: dedicated
+          operator: Equal
+          value: gpu
+          effect: NoExecute

--- a/kubernetes/main/apps/storage/rook-ceph-operator/kustomization.yaml
+++ b/kubernetes/main/apps/storage/rook-ceph-operator/kustomization.yaml
@@ -7,5 +7,7 @@ helmCharts:
     includeCRDs: true
     releaseName: rook-ceph
     repo: https://charts.rook.io/release
-    version: v1.19.8
+    version: v1.20.3
     valuesFile: values.yaml
+resources:
+  - ./ceph-csi-operator-config.yaml

--- a/kubernetes/main/apps/storage/rook-ceph-operator/values.yaml
+++ b/kubernetes/main/apps/storage/rook-ceph-operator/values.yaml
@@ -1,19 +1,3 @@
 ---
 monitoring:
   enabled: true
-csi:
-  nfs:
-    enabled: true
-  disableHolderPods: true
-  enableCSIHostNetwork: true
-  enableVolumeGroupSnapshot: false
-  pluginTolerations:
-    - key: dedicated
-      operator: Equal
-      value: gpu
-      effect: NoExecute
-  provisionerTolerations:
-    - key: dedicated
-      operator: Equal
-      value: gpu
-      effect: NoExecute


### PR DESCRIPTION
## Rook v1.20.3 Upgrade (PR B)

Bumps Rook from v1.19.8 to v1.20.3. Depends on PR A (v1.18.4 to v1.19.8) being merged first.

### Changes

**Operator (rook-ceph-operator)**
- Version bump v1.19.8 to v1.20.3
- Removed csi config keys (no longer supported in v1.20.3):
  - csi.nfs.enabled, csi.enableCSIHostNetwork, csi.enableVolumeGroupSnapshot
  - csi.disableHolderPods, csi.pluginTolerations, csi.provisionerTolerations
- Added OperatorConfig CRD (ceph-csi-operator-config.yaml) to configure gpu tolerations for CSI controller and node plugins via the ceph-csi-operator
- monitoring.enabled: true preserved

**Cluster (rook-ceph-cluster)**
- Version bump v1.19.8 to v1.20.3
- Pinned cephImage.tag: v20.2.2 (default changed from v19.2.4 to v20.2.2)
- smb.enabled: true preserved (pre-existing SMB module failure unrelated to upgrade)

### Notes
- Ceph version: v19.2.4 (squid) to v20.2.2
- ceph-csi-operator subchart: 0.6.0 to 1.0.4
- NFS CSI moves to separate ceph-csi-drivers chart (no PVs use rook NFS CSI)
- volume-group-snapshot-class.yaml preserved (uses groupsnapshot.storage.k8s.io/v1beta1)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Ceph CSI operator configuration, allowing storage plugins to run on GPU-dedicated nodes.
  * Updated the deployed Ceph storage image to version `v20.2.2`.

* **Improvements**
  * Upgraded the Rook Ceph platform from `v1.19.8` to `v1.20.3`.
  * Updated storage integration settings for improved compatibility with the newer platform release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->