### PR TITLE
chore(lemonldap): migrate to nfrastack/container-lemonldap

### DIFF
--- a/.cspell-dictionaries/homelab.txt
+++ b/.cspell-dictionaries/homelab.txt
@@ -270,7 +270,7 @@ lvm
 gitea
 raypappa
 lemonldap
-tiredofit
+nfrastack
 psessions
 llng
 tensorchord

--- a/kubernetes/main/apps/selfhosted/lemonldap/values.yaml
+++ b/kubernetes/main/apps/selfhosted/lemonldap/values.yaml
@@ -7,13 +7,12 @@ controllers:
     containers:
       app:
         image:
-          repository: tiredofit/lemonldap
-          # renovate: datasource=docker depName=tiredofit/lemonldap
-          tag: 2.0.84
+          repository: ghcr.io/nfrastack/container-lemonldap
+          # renovate: datasource=docker depName=ghcr.io/nfrastack/container-lemonldap
+          tag: "3.3.6"
           pullPolicy: IfNotPresent
         env:
           TZ: America/Los_Angeles
-          CONTAINER_NAME: lemonldap-app
           SETUP_TYPE: AUTO
           API_HOSTNAME: api.manager.sso.stoneydavis.lan
           MANAGER_HOSTNAME: manager.sso.stoneydavis.lan
@@ -48,7 +47,7 @@ persistence:
     advancedMounts:
       lemonldap-app:
         app:
-          - path: /etc/lemonldap-ng
+          - path: /config
   var-lib-lemonldap-ng-conf:
     enabled: true
     storageClass: ceph-block
@@ -61,7 +60,7 @@ persistence:
     advancedMounts:
       lemonldap-app:
         app:
-          - path: /var/lib/lemonldap-ng/conf
+          - path: /data/conf
   var-lib-lemonldap-ng-sessions:
     enabled: true
     storageClass: ceph-block
@@ -74,7 +73,7 @@ persistence:
     advancedMounts:
       lemonldap-app:
         app:
-          - path: /var/lib/lemonldap-ng/sessions
+          - path: /data/sessions
   var-lib-lemonldap-ng-psessions:
     enabled: true
     storageClass: ceph-block
@@ -87,4 +86,4 @@ persistence:
     advancedMounts:
       lemonldap-app:
         app:
-          - path: /var/lib/lemonldap-ng/psessions
+          - path: /data/psessions


### PR DESCRIPTION
Migrates LemonLDAP from deprecated `tiredofit/lemonldap:2.0.84` to `ghcr.io/nfrastack/container-lemonldap:3.3.6`.

### Changes
- Switch image to `ghcr.io/nfrastack/container-lemonldap:3.3.6`
- Update volume mount paths to match nfrastack layout:
  - `/etc/lemonldap-ng` → `/config`
  - `/var/lib/lemonldap-ng/conf` → `/data/conf`
  - `/var/lib/lemonldap-ng/sessions` → `/data/sessions`
  - `/var/lib/lemonldap-ng/psessions` → `/data/psessions`
- Remove `CONTAINER_NAME` env var (not used by nfrastack)
- Update cspell dictionary

### Notes
- PVC names kept unchanged for VolSync backup compatibility
- Since this app is currently disabled, VolSync restores will need to be re-run after enabling due to changed data paths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the LemonLDAP container to version 3.3.6.
  * Adjusted persistent storage paths to align with the updated container layout.
  * Removed an obsolete container configuration setting.
  * Updated dictionary terminology to reflect the current project name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->