### PR TITLE
fix(renovate): consolidate aws-cdk package grouping into single PR

### DIFF
--- a/.github/renovate/customVersioning.json5
+++ b/.github/renovate/customVersioning.json5
@@ -24,11 +24,7 @@
       "versioning": "regex:^RELEASE\\.(?<major>\\d+)-(?<minor>\\d+)-(?<patch>\\d+)T.*Z$",
       "matchPackagePatterns": ["minio"]
     },
-    {
-      "description": "Group aws-cdk",
-      "groupName": "aws-cdk",
-      "matchPackagePatterns": ["aws-cdk", "@aws-cdk/aws-lambda-python-alpha", "aws-cdk-lib"]
-    },
+
     {
       "description": "Group for all immich updates",
       "groupName": "immich-app",
@@ -54,6 +50,7 @@
         "monorepo:aws-cdk"
       ],
       "groupName": "aws-cdk monorepo",
+      "matchPackageNames": ["aws-cdk", "@aws-cdk/aws-lambda-python-alpha"],
       "matchUpdateTypes": [
         "digest",
         "patch",


### PR DESCRIPTION
## Problem

PRs #1140 and #1179 were separate because two conflicting grouping rules existed for aws-cdk packages:

1. A manual rule matching `aws-cdk`, `aws-cdk-lib`, `@aws-cdk/aws-lambda-python-alpha` by package name → group `"aws-cdk"`
2. A `monorepo:aws-cdk` preset matching by source URL → group `"aws-cdk monorepo"`

The `monorepo:aws-cdk` preset only matches packages from the `aws/cdk` repo, but the `aws-cdk` CLI package comes from `aws/cdk-cli` — a different repo. So they ended up in different groups/PRs.

## Fix

Removed the standalone manual rule and added `matchPackageNames` to the monorepo rule so all aws-cdk packages are grouped into a single PR.
