### PR TITLE
feat(gitea): add renovate annotation for image tag

### DIFF
--- a/kubernetes/main/apps/selfhosted/gitea/gitea-values.yaml
+++ b/kubernetes/main/apps/selfhosted/gitea/gitea-values.yaml
@@ -1,6 +1,7 @@
 ---
 image:
   repository: gitea/gitea
+  # datasource=docker depName=gitea/gitea
   tag: 1.22.2
   rootless: true
 replicaCount: 1


### PR DESCRIPTION
Adds a Renovate datasource annotation above the gitea image tag so Renovate can track and update it automatically.

Without this, only the Helm chart version in kustomization.yaml is managed — the image tag `1.22.2` was unmanaged and would drift from the chart's expected version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added dependency-tracking metadata for the Gitea container image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->