### PR TITLE
chore: bump kustomize to 5.8.1 with renovate tracking

### DIFF
--- a/.github/workflows/kustomize.yaml
+++ b/.github/workflows/kustomize.yaml
@@ -11,7 +11,8 @@ jobs:
         uses: actions/checkout@v7
       - uses: syntaqx/setup-kustomize@v1
         with:
-          kustomize-version: 5.3.0
+          # renovate: datasource=github-tags depName=kubernetes-sigs/kustomize versioning="regex:^kustomize/(?<major>\\d+)(\\.(?<minor>\\d+))?(\\.(?<patch>\\d+))?(-(?<compatibility>.*))?$"
+          kustomize-version: 5.8.1
       - uses: azure/setup-helm@v5
         with:
           version: 4.2.3

--- a/.github/workflows/kustomize.yaml
+++ b/.github/workflows/kustomize.yaml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/checkout@v7
       - uses: syntaqx/setup-kustomize@v1
         with:
-          # renovate: datasource=github-tags depName=kubernetes-sigs/kustomize versioning="regex:^kustomize/(?<major>\\d+)(\\.(?<minor>\\d+))?(\\.(?<patch>\\d+))?(-(?<compatibility>.*))?$"
+          # renovate: datasource=github-tags depName=kubernetes-sigs/kustomize extractVersion="^kustomize/v(?<version>.*)$" versioning=semver-coerced
           kustomize-version: 5.8.1
       - uses: azure/setup-helm@v5
         with:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated Kustomize workflow to use version 5.8.1.
  * Added dependency update tracking for the workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->