### PR TITLE
fix: add kubeconfig path to k3s agent taints task

### DIFF
--- a/ansible/roles/k3s_agent/tasks/taints.yml
+++ b/ansible/roles/k3s_agent/tasks/taints.yml
@@ -5,5 +5,6 @@
     state: present
     name: "{{ inventory_hostname }}"
     taints: "{{ k3s_agent_node_taints }}"
+    kubeconfig: /etc/rancher/k3s/k3s.yaml
   delegate_to: "{{ k3s_controlplane_singleton_host }}"
   when: k3s_agent_node_taints is defined and k3s_agent_node_taints | length > 0


### PR DESCRIPTION
The kubernetes.core.k8s_taint module was delegated to the control plane
host but had no kubeconfig specified, causing a No configuration found
error. Added explicit kubeconfig path to /etc/rancher/k3s/k3s.yaml.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when applying Kubernetes node taints by explicitly using the correct cluster configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->